### PR TITLE
android 5.x unmute issue

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "bluepie.ad_silence"
         minSdk 21
         targetSdk 31
-        versionCode 20
-        versionName "0.5.1"
+        versionCode 22
+        versionName "0.5.2"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/bluepie/ad_silence/NotificationListener.kt
+++ b/app/src/main/java/bluepie/ad_silence/NotificationListener.kt
@@ -49,21 +49,26 @@ class NotificationListener : NotificationListenerService() {
                         Utils().run {
                             when (NotificationParser(this@with).isAd()) {
                                 true -> {
-                                        if (!isMuted){
-                                            Log.v(TAG, "Ad detected muting, state-> $isMuted")
-                                            this.mute(audioManager, appNotificationHelper)
-                                            isMuted = true
-                                            muteCount++ // for android < M
-                                        } else {
-                                            Log.v(TAG, "Ad detected but already muted, state-> $isMuted")
-                                        }
+                                    val isMusicStreamMuted = this.isMusicMuted(audioManager!!)
+                                    if (!isMuted || !isMusicStreamMuted) {
+                                        Log.v(TAG, "'MusicStream' muted? -> $isMusicStreamMuted")
+                                        Log.v(TAG, "Ad detected muting, state-> $isMuted")
+                                        this.mute(audioManager, appNotificationHelper)
+                                        isMuted = true
+                                        muteCount.also { if (isMusicStreamMuted) 0 else muteCount++ }
+                                    } else {
+                                        Log.v(
+                                            TAG,
+                                            "Ad detected but already muted, state-> $isMuted"
+                                        )
+                                    }
                                 }
                                 false -> {
                                     isMuted.takeIf { b -> b }?.also {
                                         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
                                             Log.v(TAG, "Not an ad, Unmuting, < M")
                                             // for android 5 & 5.1, unmute has to be done, count x mutedCount
-                                            while(muteCount > 0) {
+                                            while (muteCount > 0) {
                                                 this@run.unmute(
                                                     audioManager,
                                                     appNotificationHelper,

--- a/app/src/main/java/bluepie/ad_silence/Utils.kt
+++ b/app/src/main/java/bluepie/ad_silence/Utils.kt
@@ -8,6 +8,7 @@ import android.os.Handler
 import android.os.Looper
 import android.util.Log
 import android.widget.Switch
+import kotlin.RuntimeException
 
 class Utils {
     private val TAG = "Utils"
@@ -47,6 +48,19 @@ class Utils {
     fun isPandoraInstalled(context: Context) =
         isPackageInstalled(context, context.getString(R.string.pandora_package_name))
 
+    fun isMusicMuted(audoManager: AudioManager): Boolean {
+        if (Build.VERSION.SDK_INT >= 23) {
+            return audoManager.isStreamMute(AudioManager.STREAM_MUSIC)
+        } else {
+            val volume = try {
+                audoManager.getStreamVolume(AudioManager.STREAM_MUSIC)
+            } catch (e: RuntimeException) {
+                Log.v(TAG, "Could not retrieve stream volume for stream type " + AudioManager.STREAM_MUSIC)
+                audoManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC)
+            }
+            return volume == 0
+        }
+    }
 
     fun mute(audioManager: AudioManager?, addNotificationHelper: AppNotificationHelper?) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {


### PR DESCRIPTION
Issue in android 5.x, where if `audio stream` Is muted `x` times, then unmute has to be done the same `x` times. This is not the case for android 6 & above.

#### two fixes
  - no matter how many times notification is posted by app(Spotify,accuraio...etc) mute the stream only once, then unmute later
- keep count of mute count then unmute count times


fixes #20

