### PR TITLE
Support "LiveOne"

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "bluepie.ad_silence"
         minSdk 21
         targetSdk 31
-        versionCode 24
-        versionName "0.6.0-beta"
+        versionCode 25
+        versionName "0.5.3"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "bluepie.ad_silence"
         minSdk 21
         targetSdk 31
-        versionCode 23
-        versionName "0.5.2"
+        versionCode 24
+        versionName "0.6.0-beta"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
         <package android:name="com.aspiro.tidal"/>
         <package android:name="com.spotify.lite"/>
         <package android:name="com.pandora.android"/>
+        <package android:name="com.slacker.radio"/>
     </queries>
     <application
         android:allowBackup="true"

--- a/app/src/main/java/bluepie/ad_silence/AdSilenceActivity.kt
+++ b/app/src/main/java/bluepie/ad_silence/AdSilenceActivity.kt
@@ -230,7 +230,7 @@ class AdSilenceActivity : Activity() {
                 "${context.getString(R.string.pandora)} ${
                     if (isPandoraInstalled) "" else context.getString(R.string.not_installed)
                 }".also {
-                    this.text = it
+                    this.text = "$it${applicationContext.getString(R.string.beta)}"
                 }
                 this.setOnClickListener {
                     preference.setAppConfigured(

--- a/app/src/main/java/bluepie/ad_silence/AdSilenceActivity.kt
+++ b/app/src/main/java/bluepie/ad_silence/AdSilenceActivity.kt
@@ -99,6 +99,7 @@ class AdSilenceActivity : Activity() {
         val isTidalInstalled = utils.isTidalInstalled(applicationContext)
         val isSpotifyLiteInstalled = utils.isSpotifyLiteInstalled(applicationContext)
         val isPandoraInstalled = utils.isPandoraInstalled(applicationContext)
+        val isLiveOneInstalled = utils.isLiveOneInstalled(applicationContext)
 
         findViewById<Button>(R.id.about_btn)?.setOnClickListener {
             layoutInflater.inflate(R.layout.about, null)?.run {
@@ -235,6 +236,22 @@ class AdSilenceActivity : Activity() {
                     preference.setAppConfigured(
                         SupportedApps.PANDORA,
                         !preference.isAppConfigured(SupportedApps.PANDORA)
+                    )
+                }
+            }
+
+            appSelectionView.findViewById<Switch>(R.id.liveone_selection_switch)?.run {
+                this.isEnabled = isLiveOneInstalled
+                this.isChecked = preference.isAppConfigured(SupportedApps.LiveOne)
+                "${context.getString(R.string.liveone)} ${
+                    if (isLiveOneInstalled) "" else context.getString(R.string.not_installed)
+                }".also {
+                    this.text = "$it${applicationContext.getString(R.string.beta)}"
+                }
+                this.setOnClickListener{
+                    preference.setAppConfigured(
+                        SupportedApps.LiveOne,
+                        !preference.isAppConfigured(SupportedApps.LiveOne)
                     )
                 }
             }

--- a/app/src/main/java/bluepie/ad_silence/NotificationParser.kt
+++ b/app/src/main/java/bluepie/ad_silence/NotificationParser.kt
@@ -18,6 +18,7 @@ fun AppNotification.getApp(): SupportedApps {
         context.getString(R.string.tidal_package_name) -> SupportedApps.TIDAL
         context.getString(R.string.spotify_lite_package_name) -> SupportedApps.SPOTIFY_LITE
         context.getString(R.string.pandora_package_name) -> SupportedApps.PANDORA
+        context.getString(R.string.liveOne_package_name) -> SupportedApps.LiveOne
         else -> SupportedApps.INVALID
     }
 }
@@ -31,6 +32,7 @@ fun AppNotification.adString(): List<String> {
         )
         SupportedApps.TIDAL -> listOf(context.getString(R.string.tidal_ad_string))
         SupportedApps.PANDORA -> listOf(context.getString(R.string.pandora_ad_string),context.getString(R.string.pandora_ad_string_2))
+        SupportedApps.LiveOne -> listOf(context.getString(R.string.liveOne_ad_string), context.getString(R.string.liveOne_ad_string_2))
         else -> listOf("")
     }
 }
@@ -52,6 +54,7 @@ class NotificationParser(override var appNotification: AppNotification) :
             SupportedApps.SPOTIFY, SupportedApps.SPOTIFY_LITE -> parseSpotifyNotification()
             SupportedApps.TIDAL -> parseTidalNotification()
             SupportedApps.PANDORA -> parsePandoraNotification()
+            SupportedApps.LiveOne -> parseLiveOneNotification()
             else -> false
         }
     }
@@ -149,6 +152,20 @@ class NotificationParser(override var appNotification: AppNotification) :
                     isAd = true
                     break
                 }
+            }
+        }
+        return isAd
+    }
+
+    private fun parseLiveOneNotification(): Boolean {
+        var isAd = false
+        var text = this.appNotification.notification.extras?.get("android.text").toString()
+        var title = this.appNotification.notification.extras?.get("android.title").toString()
+        for (adString in appNotification.adString()) {
+            if (text == "null" || title == adString || text == adString) {
+                Log.v(TAG, "detection in LiveOne: $adString")
+                isAd = true
+                break
             }
         }
         return isAd

--- a/app/src/main/java/bluepie/ad_silence/Preference.kt
+++ b/app/src/main/java/bluepie/ad_silence/Preference.kt
@@ -28,6 +28,8 @@ class Preference(private val context: Context) {
     private val SPOTIFY_LITE_DEFAULT = true
     val PANDORA = "Pandora"
     private val PANDORA_DEFAULT = true
+    val LIVEONE = "Liveone"
+    private val LIVEONE_DEFAULT = true
 
 
 
@@ -48,6 +50,7 @@ class Preference(private val context: Context) {
             SupportedApps.TIDAL-> preference.edit { putBoolean(TIDAL, status).commit() }
             SupportedApps.SPOTIFY_LITE-> preference.edit { putBoolean(SPOTIFY_LITE, status).commit() }
             SupportedApps.PANDORA-> preference.edit { putBoolean(PANDORA, status).commit() }
+            SupportedApps.LiveOne-> preference.edit { putBoolean(LIVEONE, status).commit() }
         }
     }
 
@@ -58,6 +61,7 @@ class Preference(private val context: Context) {
             SupportedApps.TIDAL-> preference.getBoolean(TIDAL, TIDAL_DEFAULT)
             SupportedApps.SPOTIFY_LITE-> preference.getBoolean(SPOTIFY_LITE, SPOTIFY_LITE_DEFAULT)
             SupportedApps.PANDORA-> preference.getBoolean(PANDORA, PANDORA_DEFAULT)
+            SupportedApps.LiveOne-> preference.getBoolean(LIVEONE, LIVEONE_DEFAULT)
             else -> false
         }
 

--- a/app/src/main/java/bluepie/ad_silence/SupportedApps.kt
+++ b/app/src/main/java/bluepie/ad_silence/SupportedApps.kt
@@ -6,5 +6,6 @@ enum class SupportedApps {
     TIDAL,
     SPOTIFY_LITE,
     PANDORA,
+    LiveOne,
     INVALID
 }

--- a/app/src/main/java/bluepie/ad_silence/Utils.kt
+++ b/app/src/main/java/bluepie/ad_silence/Utils.kt
@@ -48,6 +48,9 @@ class Utils {
     fun isPandoraInstalled(context: Context) =
         isPackageInstalled(context, context.getString(R.string.pandora_package_name))
 
+    fun isLiveOneInstalled(context: Context) =
+        isPackageInstalled(context, context.getString(R.string.liveOne_package_name))
+
     fun isMusicMuted(audoManager: AudioManager): Boolean {
         if (Build.VERSION.SDK_INT >= 23) {
             return audoManager.isStreamMute(AudioManager.STREAM_MUSIC)
@@ -55,7 +58,10 @@ class Utils {
             val volume = try {
                 audoManager.getStreamVolume(AudioManager.STREAM_MUSIC)
             } catch (e: RuntimeException) {
-                Log.v(TAG, "Could not retrieve stream volume for stream type " + AudioManager.STREAM_MUSIC)
+                Log.v(
+                    TAG,
+                    "Could not retrieve stream volume for stream type " + AudioManager.STREAM_MUSIC
+                )
                 audoManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC)
             }
             return volume == 0

--- a/app/src/main/res/layout/app_selection.xml
+++ b/app/src/main/res/layout/app_selection.xml
@@ -35,29 +35,17 @@
         android:text="@string/tidal" />
 
     <Switch
-        android:id="@+id/liveone_selection_switch"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:minHeight="48dp"
-        android:text="@string/liveone" />
-
-    <TextView
-        android:id="@+id/experimental_view"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:gravity="center"
-        android:paddingTop="4dp"
-        android:text="@string/Experimental"
-        android:textColor="#FFFFFF"
-        android:textSize="20sp"
-        android:textStyle="bold" />
-
-    <Switch
         android:id="@+id/pandora_selection_switch"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:minHeight="48dp"
         android:text="@string/pandora" />
+
+    <Switch
+        android:id="@+id/liveone_selection_switch"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:minHeight="48dp"
+        android:text="@string/liveone" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/app_selection.xml
+++ b/app/src/main/res/layout/app_selection.xml
@@ -34,6 +34,13 @@
         android:minHeight="48dp"
         android:text="@string/tidal" />
 
+    <Switch
+        android:id="@+id/liveone_selection_switch"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:minHeight="48dp"
+        android:text="@string/liveone" />
+
     <TextView
         android:id="@+id/experimental_view"
         android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,4 +49,6 @@
     <string name="liveOne_package_name">com.slacker.radio</string>
     <string name="liveOne_ad_string">Advertisement</string>
     <string name="liveOne_ad_string_2">60 Minutes Uninterrupted Listening</string>
+    <string name="liveone">LiveOne</string>
+    <string name="beta"> (Beta)</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,4 +46,7 @@
     <string name="pandora_ad_string">Advertisement</string>
     <string name="pandora_ad_string_2">Skip Limit Exceeded</string>
     <string name="Experimental">Experimental</string>
+    <string name="liveOne_package_name">com.slacker.radio</string>
+    <string name="liveOne_ad_string">Advertisement</string>
+    <string name="liveOne_ad_string_2">60 Minutes Uninterrupted Listening</string>
 </resources>

--- a/fastlane/metadata/android/en-US/changelogs/25.txt
+++ b/fastlane/metadata/android/en-US/changelogs/25.txt
@@ -1,0 +1,2 @@
+- add LiveOne support (unstable)
+- ui changes


### PR DESCRIPTION
**This PR extends support for "LiveOne"** - closes #28 

link to app "https://play.google.com/store/apps/details?id=com.slacker.radio"

app can be used to stream music.

pros (specific to listening music):
- can be used to stream music (audio), there is trivia for the songs.
- multiple stations

cons:
 - region blocked (can't install via playstore)
 - even if you use unofficial apk (they have restrictions based on ip, thus a vpn is necessary)

notes:
App plays trivia about the next song, but this should not be blocked...only advertisements should be blocked.