### PR TITLE
new way of detecting ads in Spotify

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "bluepie.ad_silence"
         minSdk 21
         targetSdk 31
-        versionCode 30
-        versionName "0.5.4"
+        versionCode 36
+        versionName "0.5.5-test"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,7 +10,7 @@ android {
         applicationId "bluepie.ad_silence"
         minSdk 21
         targetSdk 31
-        versionCode 37
+        versionCode 38
         versionName "0.5.5-test"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,7 +10,7 @@ android {
         applicationId "bluepie.ad_silence"
         minSdk 21
         targetSdk 31
-        versionCode 36
+        versionCode 37
         versionName "0.5.5-test"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/java/bluepie/ad_silence/NotificationParser.kt
+++ b/app/src/main/java/bluepie/ad_silence/NotificationParser.kt
@@ -121,7 +121,6 @@ class NotificationParser(override var appNotification: AppNotification) :
         )
 
         var isAd = false
-        Log.v(TAG, "[spotify notification][new detection] "+ this.appNotification.notification.extras.toString())
         this.appNotification.notification.extras?.get("android.title").toString().run {
             Log.v(TAG, "trying match against \"$this\" with ${appNotification.adString().take(40)}")
             for (adString in appNotification.adString()) {
@@ -133,14 +132,28 @@ class NotificationParser(override var appNotification: AppNotification) :
             }
         }
 
+        Log.v(TAG, "[spotify notification][new detection] "+ this.appNotification.notification.extras.toString())
+        Log.v(TAG, "[spotify notification][new detection] ticker: ${this.appNotification.notification.tickerText}" )
+
+        // miui & stock seems to have sub & txt reversed, https://github.com/aghontpi/ad-silence/pull/64
+        val spotifyAdText = appNotification.context.getString(R.string.spotify_ad2);
+
+        if (!isAd) {
+            // new add detection method https://github.com/aghontpi/ad-silence/issues/63
+            this.appNotification.notification.extras?.get("android.subText") .toString().run {
+                if (this.contains(spotifyAdText) || this == spotifyAdText) {
+                    Log.v(TAG,"[new detection][spotify] detected subTxt: '${this}'")
+                    isAd = true
+                }
+            }
+        }
+
         if (!isAd) {
             // new add detection method https://github.com/aghontpi/ad-silence/issues/63
             this.appNotification.notification.extras?.get("android.text") .toString().run {
-                if (this.contains("Spotify") || this == "Spotify" || this == "") {
-                    Log.v(TAG,"[new detection][spotify] detected: '${this}'")
+                if (this.contains(spotifyAdText) || this == spotifyAdText) {
+                    Log.v(TAG,"[spotify][new detection] detected txt: '${this}'")
                     isAd = true
-                } else {
-                    Log.v(TAG,"[new detection][spotify] not detected: '${this}'")
                 }
             }
         }

--- a/app/src/main/java/bluepie/ad_silence/NotificationParser.kt
+++ b/app/src/main/java/bluepie/ad_silence/NotificationParser.kt
@@ -158,6 +158,26 @@ class NotificationParser(override var appNotification: AppNotification) :
             }
         }
 
+
+        if (!isAd) {
+            //https://github.com/aghontpi/ad-silence/pull/64#issuecomment-1179105786
+            //also refer miui & stock comment above
+            listOf(this.appNotification.notification.extras?.get("android.subText"),
+                this.appNotification.notification.extras?.get("android.title"),
+                this.appNotification.notification.extras?.get("android.text")).forEach { diffTypeString ->
+                val songString = diffTypeString.toString();
+                if (songString != "null" && songString is String && !isAd) {
+                    val isMatchFound = appNotification.adString().filter { songString.contains(it, ignoreCase = true) }
+                    if (isMatchFound.isNotEmpty() && !isAd) {
+                        Log.v(TAG, "[spotify][new detection][regex match] found \"${isMatchFound.joinToString(separator=",")}\" against \"$songString\"")
+                        isAd = true
+                    }
+                }
+            }
+
+
+        }
+
         return isAd
     }
 

--- a/app/src/main/java/bluepie/ad_silence/NotificationParser.kt
+++ b/app/src/main/java/bluepie/ad_silence/NotificationParser.kt
@@ -121,8 +121,9 @@ class NotificationParser(override var appNotification: AppNotification) :
         )
 
         var isAd = false
+        Log.v(TAG, "[spotify notification][new detection] "+ this.appNotification.notification.extras.toString())
         this.appNotification.notification.extras?.get("android.title").toString().run {
-            Log.v(TAG, "trying match against \"$this\" with ${appNotification.adString()}")
+            Log.v(TAG, "trying match against \"$this\" with ${appNotification.adString().take(40)}")
             for (adString in appNotification.adString()) {
                 if (this == adString) {
                     Log.v(TAG, "detection in Spotify: $adString")
@@ -131,6 +132,19 @@ class NotificationParser(override var appNotification: AppNotification) :
                 }
             }
         }
+
+        if (!isAd) {
+            // new add detection method https://github.com/aghontpi/ad-silence/issues/63
+            this.appNotification.notification.extras?.get("android.text") .toString().run {
+                if (this.contains("Spotify") || this == "Spotify" || this == "") {
+                    Log.v("TAG","[new detection][spotify] detected: '${this}'")
+                    isAd = true
+                } else {
+                    Log.v("TAG","[new detection][spotify] not detected: '${this}'")
+                }
+            }
+        }
+
         return isAd
     }
 

--- a/app/src/main/java/bluepie/ad_silence/NotificationParser.kt
+++ b/app/src/main/java/bluepie/ad_silence/NotificationParser.kt
@@ -137,10 +137,10 @@ class NotificationParser(override var appNotification: AppNotification) :
             // new add detection method https://github.com/aghontpi/ad-silence/issues/63
             this.appNotification.notification.extras?.get("android.text") .toString().run {
                 if (this.contains("Spotify") || this == "Spotify" || this == "") {
-                    Log.v("TAG","[new detection][spotify] detected: '${this}'")
+                    Log.v(TAG,"[new detection][spotify] detected: '${this}'")
                     isAd = true
                 } else {
-                    Log.v("TAG","[new detection][spotify] not detected: '${this}'")
+                    Log.v(TAG,"[new detection][spotify] not detected: '${this}'")
                 }
             }
         }


### PR DESCRIPTION
refer #63

**Test out new ad detection for Spotify.**

On top of the existing detections, added new logic to detect ads, if the old logic does not catch the ads, the new logic is activated.

did not remove old detection because that might cause bugs/unexpected behaviour in existing flow. 


closes #63 