### PR TITLE
Disable Dependency Metadata for APKs but Retain for App Bundles

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,6 +44,13 @@ android {
     lint {
         checkDependencies true
     }
+
+    dependenciesInfo {
+        // Disables dependency metadata when building APKs.
+        includeInApk = false
+        // Keep dependency metadata when building Android App Bundles.
+        includeInBundle = true
+    }
 }
 
 dependencies {


### PR DESCRIPTION
This PR disables the inclusion of dependency metadata in APK builds while retaining it for Android App Bundles. This change addresses reproducible build issues reported by IzzyOnDroid, ensuring APK builds do not contain Google's encrypted dependency metadata blob (DEPENDENCY_INFO_BLOCK).



closes https://github.com/aghontpi/ad-silence/issues/163