### PR TITLE
Feat: add settings menu, option to choose how mute is handled.

### DIFF
--- a/app/src/main/java/bluepie/ad_silence/AdSilenceActivity.kt
+++ b/app/src/main/java/bluepie/ad_silence/AdSilenceActivity.kt
@@ -32,6 +32,7 @@ class AdSilenceActivity : Activity() {
     private var appSelectionDialog: AlertDialog? = null
     private var addCustomAppDialog: AlertDialog? = null
     private var deleteCustomAppDialog: AlertDialog? = null
+    private var settingsDialog: AlertDialog? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -82,6 +83,10 @@ class AdSilenceActivity : Activity() {
         if (deleteCustomAppDialog != null && deleteCustomAppDialog!!.isShowing) {
             Log.v(TAG, "Dismissing delete custom app dialog")
             deleteCustomAppDialog!!.dismiss()
+        }
+        if (settingsDialog != null && settingsDialog!!.isShowing) {
+            Log.v(TAG, "Dismissing settings dialog")
+            settingsDialog!!.dismiss()
         }
     }
 
@@ -310,6 +315,10 @@ class AdSilenceActivity : Activity() {
         val versionCode = BuildConfig.VERSION_CODE
         val versionName = BuildConfig.VERSION_NAME
         findViewById<TextView>(R.id.app_version)?.text = "$versionName"
+
+        findViewById<Button>(R.id.settings_btn)?.setOnClickListener {
+            showSettingsDialog()
+        }
 
         findViewById<Button>(R.id.about_btn)?.setOnClickListener {
             layoutInflater.inflate(R.layout.about, null)?.run {
@@ -964,6 +973,39 @@ class AdSilenceActivity : Activity() {
             return
         }
         Log.v(TAG, "[permission] notification permission not granted")
+    }
+
+
+    private fun showSettingsDialog() {
+        val dialogView = layoutInflater.inflate(R.layout.dialog_settings, null)
+        val dialog = AlertDialog.Builder(this)
+            .setView(dialogView)
+            .create()
+
+        val preference = Preference(applicationContext)
+
+        dialogView.findViewById<TextView>(R.id.tv_mute_behavior_help)?.run {
+            setTextFromHtml(this, getString(R.string.mute_behavior_help))
+            this.movementMethod = LinkMovementMethod.getInstance()
+        }
+
+        dialogView.findViewById<Switch>(R.id.switch_mute_entire_device)?.apply {
+            isChecked = preference.isMuteEntireDeviceEnabled()
+            setOnCheckedChangeListener { _, isChecked ->
+                preference.setMuteEntireDeviceEnabled(isChecked)
+            }
+        }
+
+        dialogView.findViewById<Button>(R.id.btn_close_settings)?.setOnClickListener {
+            dialog.dismiss()
+        }
+
+        dialog.window?.setBackgroundDrawableResource(android.R.color.transparent)
+        settingsDialog = dialog
+        dialog.setOnDismissListener {
+            settingsDialog = null
+        }
+        dialog.show()
     }
 
 }

--- a/app/src/main/java/bluepie/ad_silence/Preference.kt
+++ b/app/src/main/java/bluepie/ad_silence/Preference.kt
@@ -162,6 +162,22 @@ class Preference(private val context: Context) {
             putBoolean(DEBUG_LOG_ENABLED, status).commit()
         }
     }
+
+    /* Mute Behavior Preferences */
+    private val MUTE_ENTIRE_DEVICE = "MuteEntireDevice"
+    private val MUTE_ENTIRE_DEVICE_DEFAULT = false
+
+    fun isMuteEntireDeviceEnabled(): Boolean {
+        return preference.getBoolean(MUTE_ENTIRE_DEVICE, MUTE_ENTIRE_DEVICE_DEFAULT)
+    }
+
+    fun setMuteEntireDeviceEnabled(status: Boolean) {
+        Log.v(TAG, "[configMuteEntireDevice] ${isMuteEntireDeviceEnabled()} -> $status")
+        preference.edit {
+            putBoolean(MUTE_ENTIRE_DEVICE, status).commit()
+        }
+    }
+
     private val CUSTOM_APPS = "CustomApps"
 
     companion object {

--- a/app/src/main/java/bluepie/ad_silence/Utils.kt
+++ b/app/src/main/java/bluepie/ad_silence/Utils.kt
@@ -72,13 +72,10 @@ class Utils {
     }
 
     fun mute(audioManager: AudioManager?, addNotificationHelper: AppNotificationHelper?, preference: Preference) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            audioManager?.adjustVolume(
-                AudioManager.ADJUST_MUTE,
-                AudioManager.FLAG_PLAY_SOUND
-            )
+        if (preference.isMuteEntireDeviceEnabled() && Build.VERSION.SDK_INT >= 23) {
+             audioManager?.adjustVolume(AudioManager.ADJUST_MUTE, 0)
         } else {
-            audioManager?.setStreamMute(AudioManager.STREAM_MUSIC, true)
+             audioManager?.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_MUTE, 0)
         }
 
         this.updateNotification("AdSilence, ad-detected", preference, addNotificationHelper)
@@ -98,13 +95,10 @@ class Utils {
         app: SupportedApps,
         preference: Preference
     ) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            audioManager?.adjustVolume(
-                AudioManager.ADJUST_UNMUTE,
-                AudioManager.FLAG_PLAY_SOUND
-            )
+        if (preference.isMuteEntireDeviceEnabled() && Build.VERSION.SDK_INT >= 23) {
+             audioManager?.adjustVolume(AudioManager.ADJUST_UNMUTE, 0)
         } else {
-            audioManager?.setStreamMute(AudioManager.STREAM_MUSIC, false)
+             audioManager?.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_UNMUTE, 0)
         }
 
         this.updateNotification("AdSilence, listening for ads", preference, addNotificationHelper)

--- a/app/src/main/res/layout/activity_ad_silence.xml
+++ b/app/src/main/res/layout/activity_ad_silence.xml
@@ -198,6 +198,15 @@
             android:textColor="?android:attr/textColorPrimary" />
 
         <Button
+            android:id="@+id/settings_btn"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:background="@drawable/bg_button_rounded"
+            android:text="@string/settings"
+            android:textColor="?android:attr/textColorPrimary" />
+
+        <Button
             android:id="@+id/about_btn"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/dialog_settings.xml
+++ b/app/src/main/res/layout/dialog_settings.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/bg_dialog_rounded"
+    android:orientation="vertical"
+    android:padding="24dp">
+
+    <TextView
+        android:id="@+id/tv_settings_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:text="@string/settings"
+        android:textColor="?android:attr/textColorPrimary"
+        android:textSize="20sp"
+        android:textStyle="bold" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/mute_behavior_title"
+            android:textColor="?android:attr/textColorPrimary"
+            android:textSize="16sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/tv_mute_behavior_help"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:text="@string/mute_behavior_help"
+            android:textColor="?android:attr/textColorSecondary"
+            android:textSize="12sp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:layout_marginTop="8dp">
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/mute_entire_device"
+                    android:textColor="?android:attr/textColorPrimary"
+                    android:textSize="14sp" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/mute_entire_device_desc"
+                    android:textColor="?android:attr/textColorSecondary"
+                    android:textSize="12sp" />
+
+            </LinearLayout>
+
+            <Switch
+                android:id="@+id/switch_mute_entire_device"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp" />
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+    <Button
+        android:id="@+id/btn_close_settings"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:background="@drawable/bg_button_rounded"
+        android:text="@string/close"
+        android:textColor="?android:attr/textColorPrimary" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,4 +102,11 @@
     <string name="clear">Clear</string>
     <string name="channel_name">Service Status</string>
     <string name="channel_description">Persistent notification showing that AdSilence is active</string>
+
+    <!-- Settings Strings -->
+    <string name="settings">Settings</string>
+    <string name="mute_behavior_title">Mute Behavior</string>
+    <string name="mute_entire_device">Mute Entire Device</string>
+    <string name="mute_entire_device_desc">If enabled, the entire device (including ringer) will be muted. If disabled, only the music stream is muted.</string>
+    <string name="mute_behavior_help">Not sure which one to choose? <![CDATA[<a href="https://github.com/aghontpi/ad-silence/wiki/Mute%E2%80%90behaviour%E2%80%90settings">Read here!</a>]]></string>
 </resources>


### PR DESCRIPTION
This pr introduces settings menu, the settings menu has the following items
- mute option (music stream or entire device stream)
  - by default change the mute logic to music stream