### PR TITLE
Feat: remove custom app from main activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ You can now add any app to Ad-silence to mute its notifications.
 Wiki: https://github.com/aghontpi/ad-silence/wiki/Custom_App_Wiki
 
 1. Open Ad-silence.
-2. Scroll down to "Custom Apps" section.
-3. Click on "Add" button.
+2. Click on "Select Apps" button.
+3. Scroll down to the bottom and click on "Add Custom App" button.
 4. Enter the name, **Package Name** of the app (e.g., `com.example.radio`).
 5. Enter **Keywords** to trigger muting only on specific notifications.
 6. Click on "Save" button.

--- a/app/src/main/java/bluepie/ad_silence/AdSilenceActivity.kt
+++ b/app/src/main/java/bluepie/ad_silence/AdSilenceActivity.kt
@@ -342,9 +342,7 @@ class AdSilenceActivity : Activity() {
             }
         }
 
-        findViewById<Button>(R.id.add_custom_app_btn)?.setOnClickListener {
-            showAddCustomAppDialog()
-        }
+
 
         findViewById<Button>(R.id.debug_log_btn)?.setOnClickListener {
             showDebugLogDialog()

--- a/app/src/main/res/layout/activity_ad_silence.xml
+++ b/app/src/main/res/layout/activity_ad_silence.xml
@@ -207,34 +207,6 @@
             android:textColor="?android:attr/textColorPrimary" />
     </LinearLayout>
 
-    <!-- Custom Detection Card -->
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        android:background="@drawable/bg_card_rounded"
-        android:orientation="vertical"
-        android:gravity="center"
-        android:padding="16dp">
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="12dp"
-            android:text="@string/custom_detection"
-            android:textColor="?android:attr/textColorPrimary"
-            android:textSize="16sp" />
-
-        <Button
-            android:id="@+id/add_custom_app_btn"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="@drawable/bg_button_rounded"
-            android:text="@string/add_custom_app"
-            android:textColor="?android:attr/textColorPrimary" />
-
-    </LinearLayout>
-    
     <!-- Hidden views to prevent logic breakage if they are referenced, from old design, remove it
      after couple of releases -->
     <TextView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,7 +97,7 @@
     <string name="ad_muting_status">Ad-Muting Status</string>
     <string name="enable_ad_silence">Enable Ad-Silence</string>
     <string name="debug_log">Debug Log</string>
-    <string name="custom_detection">Custom Detection</string>
+
     <string name="mock">Mock</string>
     <string name="clear">Clear</string>
     <string name="channel_name">Service Status</string>


### PR DESCRIPTION
Since we already have the add custom app in select apps menu, removing it from main activity, be clutter free.