### PR TITLE
feat: Add unmute delay to custom app,

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ Wiki: https://github.com/aghontpi/ad-silence/wiki/Custom_App_Wiki
 3. Scroll down to the bottom and click on "Add Custom App" button.
 4. Enter the name, **Package Name** of the app (e.g., `com.example.radio`).
 5. Enter **Keywords** to trigger muting only on specific notifications.
-6. Click on "Save" button.
+6. (Optional) Enter **Unmute Delay** to wait before unmuting (useful for some apps).
+7. Click on "Save" button.
 
 > **Note:**
 > - The app will be muted only if the notification contains the keywords.
@@ -64,6 +65,7 @@ Wiki: https://github.com/aghontpi/ad-silence/wiki/Custom_App_Wiki
 > - click on the edit icon to edit it.
 > - Enter the new name, **Package Name** of the app (e.g., `com.example.radio`).
 > - Enter **Keywords** to trigger muting only on specific notifications.
+> - (Optional) Update **Unmute Delay**.
 > - Click on "Save" button.
 
 > **Deleting:**

--- a/app/src/main/java/bluepie/ad_silence/AdSilenceActivity.kt
+++ b/app/src/main/java/bluepie/ad_silence/AdSilenceActivity.kt
@@ -789,6 +789,7 @@ class AdSilenceActivity : Activity() {
             dialogView.findViewById<EditText>(R.id.et_app_name).setText(appToEdit.name)
             dialogView.findViewById<EditText>(R.id.et_package_name).setText(appToEdit.packageName)
             dialogView.findViewById<EditText>(R.id.et_keywords).setText(appToEdit.keywords.joinToString(", "))
+            dialogView.findViewById<EditText>(R.id.et_unmute_delay).setText(appToEdit.unmuteDelay.toString())
         } else {
             titleView.text = getString(R.string.add_custom_app)
         }
@@ -826,8 +827,10 @@ class AdSilenceActivity : Activity() {
                 }
             }
 
+            val unmuteDelayText = dialogView.findViewById<EditText>(R.id.et_unmute_delay).text.toString()
+            val unmuteDelay = unmuteDelayText.toLongOrNull() ?: 0L
             val keywords = keywordsText.split(",").map { it.trim() }.filter { it.isNotEmpty() }
-            val customApp = CustomApp(appName, packageName, keywords, appToEdit?.isEnabled ?: true)
+            val customApp = CustomApp(appName, packageName, keywords, appToEdit?.isEnabled ?: true, unmuteDelay)
 
             if (appToEdit != null && appToEdit.packageName != packageName) {
                 preference.removeCustomApp(appToEdit.packageName)

--- a/app/src/main/java/bluepie/ad_silence/CustomApp.kt
+++ b/app/src/main/java/bluepie/ad_silence/CustomApp.kt
@@ -4,5 +4,6 @@ data class CustomApp(
     val name: String,
     val packageName: String,
     val keywords: List<String>,
-    var isEnabled: Boolean = true
+    var isEnabled: Boolean = true,
+    val unmuteDelay: Long = 0
 )

--- a/app/src/main/java/bluepie/ad_silence/NotificationListener.kt
+++ b/app/src/main/java/bluepie/ad_silence/NotificationListener.kt
@@ -304,7 +304,7 @@ class NotificationListener : NotificationListenerService() {
                                                 unmuteRunnable = null
                                             }
 
-                                            val delay = this.getUnmuteDelay(currentPackage)
+                                            val delay = this.getUnmuteDelay(currentPackage, packageName, preference)
                                             if (delay > 0) {
                                                 Log.v(TAG, "scheduling unmute for $currentPackage ($packageName) with delay $delay")
                                                 if (isDebugEnabled) {

--- a/app/src/main/java/bluepie/ad_silence/Preference.kt
+++ b/app/src/main/java/bluepie/ad_silence/Preference.kt
@@ -203,7 +203,8 @@ class Preference(private val context: Context) {
                     keywords.add(keywordsJsonArray.getString(j))
                 }
                 val isEnabled = jsonObject.optBoolean("isEnabled", true)
-                customApps.add(CustomApp(name, packageName, keywords, isEnabled))
+                val unmuteDelay = jsonObject.optLong("unmuteDelay", 0)
+                customApps.add(CustomApp(name, packageName, keywords, isEnabled, unmuteDelay))
             }
         } catch (e: Exception) {
             Log.e(TAG, "Error parsing custom apps", e)
@@ -248,6 +249,7 @@ class Preference(private val context: Context) {
             app.keywords.forEach { keywordsArray.put(it) }
             jsonObject.put("keywords", keywordsArray)
             jsonObject.put("isEnabled", app.isEnabled)
+            jsonObject.put("unmuteDelay", app.unmuteDelay)
             jsonArray.put(jsonObject)
         }
         preference.edit { putString(CUSTOM_APPS, jsonArray.toString()).commit() }

--- a/app/src/main/java/bluepie/ad_silence/Utils.kt
+++ b/app/src/main/java/bluepie/ad_silence/Utils.kt
@@ -81,7 +81,10 @@ class Utils {
         this.updateNotification("AdSilence, ad-detected", preference, addNotificationHelper)
     }
 
-    fun getUnmuteDelay(app: SupportedApps): Long {
+    fun getUnmuteDelay(app: SupportedApps, packageName: String? = null, preference: Preference? = null): Long {
+        if (app == SupportedApps.CUSTOM && packageName != null && preference != null) {
+            return preference.getCustomApps().find { it.packageName == packageName }?.unmuteDelay ?: 0
+        }
         return when (app) {
             SupportedApps.SPOTIFY_LITE -> 540
             SupportedApps.SPOTIFY -> 480

--- a/app/src/main/res/layout/dialog_add_custom_app.xml
+++ b/app/src/main/res/layout/dialog_add_custom_app.xml
@@ -106,6 +106,44 @@
             android:textStyle="italic"
             android:textSize="11sp" />
     </LinearLayout>
+    
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="4dp"
+            android:layout_marginLeft="16dp"
+            android:layout_marginStart="16dp"
+            android:text="Unmute Delay (ms)"
+            android:textColor="?android:attr/textColorSecondary"
+            android:textSize="12sp" />
+
+        <EditText
+            android:id="@+id/et_unmute_delay"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@drawable/bg_edit_text"
+            android:hint="0"
+            android:inputType="number"
+            android:textColor="?android:attr/textColorPrimary"
+            android:textColorHint="?android:attr/textColorHint"
+            android:textSize="16sp" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:layout_marginLeft="16dp"
+            android:layout_marginStart="16dp"
+            android:text="Delay in milliseconds before unmuting (0 for instant)"
+            android:textColor="?android:attr/textColorSecondary"
+            android:textSize="12sp" />
+    </LinearLayout>
 
     <LinearLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
This **PR** is responsible for adding unmute delay for custom apps.

- [x] Add/edit custom apps should have unmute delay
- [x] update the log msg in debug view
- [x] unmute logic in service
- [x] update preference logic to store and retrieve the custom unmute delay.

updated wiki here: https://github.com/aghontpi/ad-silence/wiki/Custom_App_Wiki