### PR TITLE
Feat: Force mute the music stream by default.

### DIFF
--- a/app/src/main/java/bluepie/ad_silence/AdSilenceActivity.kt
+++ b/app/src/main/java/bluepie/ad_silence/AdSilenceActivity.kt
@@ -996,6 +996,13 @@ class AdSilenceActivity : Activity() {
             }
         }
 
+        dialogView.findViewById<Switch>(R.id.switch_force_mute_no_check)?.apply {
+            isChecked = preference.isForceMuteNoCheckEnabled()
+            setOnCheckedChangeListener { _, isChecked ->
+                preference.setForceMuteNoCheckEnabled(isChecked)
+            }
+        }
+
         dialogView.findViewById<Button>(R.id.btn_close_settings)?.setOnClickListener {
             dialog.dismiss()
         }

--- a/app/src/main/java/bluepie/ad_silence/NotificationListener.kt
+++ b/app/src/main/java/bluepie/ad_silence/NotificationListener.kt
@@ -238,7 +238,14 @@ class NotificationListener : NotificationListenerService() {
                                         }
                                     }
 
-                                    val isMusicStreamMuted = this.isMusicMuted(audioManager!!)
+                                    val isForceMuteNoCheckEnabled = preference.isForceMuteNoCheckEnabled()
+                                    var isMusicStreamMuted = this.isMusicMuted(audioManager!!)
+                                    
+                                    if (isForceMuteNoCheckEnabled) {
+                                        Log.v(TAG, "Force mute enabled, ignoring existing mute state")
+                                        isMusicStreamMuted = false
+                                    }
+
                                     if (!isMuted || !isMusicStreamMuted) {
                                         Log.v(TAG, "'MusicStream' muted? -> $isMusicStreamMuted")
                                         Log.v(TAG, "Ad detected muting, state-> $isMuted to ${!isMuted}, currentPackage: $currentPackage")

--- a/app/src/main/java/bluepie/ad_silence/Preference.kt
+++ b/app/src/main/java/bluepie/ad_silence/Preference.kt
@@ -178,6 +178,20 @@ class Preference(private val context: Context) {
         }
     }
 
+    private val FORCE_MUTE_NO_CHECK = "ForceMuteNoCheck"
+    private val FORCE_MUTE_NO_CHECK_DEFAULT = true
+
+    fun isForceMuteNoCheckEnabled(): Boolean {
+        return preference.getBoolean(FORCE_MUTE_NO_CHECK, FORCE_MUTE_NO_CHECK_DEFAULT)
+    }
+
+    fun setForceMuteNoCheckEnabled(status: Boolean) {
+        Log.v(TAG, "[configForceMuteNoCheck] ${isForceMuteNoCheckEnabled()} -> $status")
+        preference.edit {
+            putBoolean(FORCE_MUTE_NO_CHECK, status).commit()
+        }
+    }
+
     private val CUSTOM_APPS = "CustomApps"
 
     companion object {

--- a/app/src/main/res/layout/dialog_settings.xml
+++ b/app/src/main/res/layout/dialog_settings.xml
@@ -75,6 +75,43 @@
 
         </LinearLayout>
 
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:layout_marginTop="16dp">
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/force_mute_title"
+                    android:textColor="?android:attr/textColorPrimary"
+                    android:textSize="14sp" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/force_mute_desc"
+                    android:textColor="?android:attr/textColorSecondary"
+                    android:textSize="12sp" />
+
+            </LinearLayout>
+
+            <Switch
+                android:id="@+id/switch_force_mute_no_check"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp" />
+
+        </LinearLayout>
+
     </LinearLayout>
 
     <Button

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -74,4 +74,6 @@
     <string name="channel_name">Stato del servizio</string>
     <string name="channel_description">Notifica persistente che mostra che AdSilence è attivo</string>
     <string name="notification_update_help">Se il silenziamento o il rilevamento non funzionano, prova ad abilitare questa opzione.</string>
+    <string name="force_mute_title">Force Mute (Don\'t check existing mute)</string>
+    <string name="force_mute_desc">Mute ads without checking if the media is already muted.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -110,4 +110,6 @@
     <string name="mute_entire_device">Mute Entire Device</string>
     <string name="mute_entire_device_desc">If enabled, the entire device (including ringer) will be muted. If disabled, only the music stream is muted.</string>
     <string name="mute_behavior_help">Not sure which one to choose? <![CDATA[<a href="https://github.com/aghontpi/ad-silence/wiki/Mute%E2%80%90behaviour%E2%80%90settings">Read here!</a>]]></string>
+    <string name="force_mute_title">Force Mute (Don\'t check existing mute)</string>
+    <string name="force_mute_desc">Mute ads without checking if the media is already muted.</string>
 </resources>


### PR DESCRIPTION
This *PR* adds the ability to force mute the music stream, when user unmutes the device, if the notifications is received again, it will mute the stream again.

User can change this behaviour in settings 

if status of the app is turned off, then it wont affect any behaviour.


<img width="380" height="auto" alt="Screenshot_20251220-202544" src="https://github.com/user-attachments/assets/31eb5212-ac1d-4f88-bfdd-33997a24aee3" />

As part of this change, the settings page wiki is also being updated here: https://github.com/aghontpi/ad-silence/wiki/Mute%E2%80%90behaviour%E2%80%90settings
