### PR TITLE
Feat: Add Cast support

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -5,6 +5,12 @@ on:
     branches: [ "master", "development" ]
   pull_request:
     branches: [ "master", "development" ]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Pull Request Number (Required for manual PR builds)'
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -16,6 +22,19 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
+      - name: Determine Execution Context
+        id: context
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+            echo "IS_PR_BUILD=true" >> $GITHUB_ENV
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]] && [[ -n "${{ inputs.pr_number }}" ]]; then
+            echo "PR_NUMBER=${{ inputs.pr_number }}" >> $GITHUB_ENV
+            echo "IS_PR_BUILD=true" >> $GITHUB_ENV
+          else
+            echo "IS_PR_BUILD=false" >> $GITHUB_ENV
+          fi
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3
@@ -52,14 +71,14 @@ jobs:
           echo "VERSION_NAME=$VERSION_NAME" >> $GITHUB_ENV
 
       - name: Rename APK
-        if: github.event_name == 'pull_request'
+        if: env.IS_PR_BUILD == 'true'
         run: |
-          APK_PATH="app/build/outputs/apk/debug/ad-silence-debug-build-${{ env.VERSION_NAME }}-${{ github.event.pull_request.number }}.apk"
+          APK_PATH="app/build/outputs/apk/debug/ad-silence-debug-build-${{ env.VERSION_NAME }}-${{ env.PR_NUMBER }}.apk"
           mv app/build/outputs/apk/debug/app-debug.apk $APK_PATH
           echo "APK_PATH=$APK_PATH" >> $GITHUB_ENV
 
       - name: Extract APK SHA-256 Fingerprint
-        if: github.event_name == 'pull_request'
+        if: env.IS_PR_BUILD == 'true'
         run: |
           echo "Extracting SHA-256 for: ${{ env.APK_PATH }}"
           
@@ -81,7 +100,7 @@ jobs:
           path: app/build/outputs/apk/debug/*.apk
 
       - name: Deploy to builds branch
-        if: github.event_name == 'pull_request'
+        if: env.IS_PR_BUILD == 'true'
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
@@ -98,8 +117,8 @@ jobs:
           (mkdir /tmp/builds_repo && cd /tmp/builds_repo && git init && git checkout -b builds && git remote add origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }})
           
           cd /tmp/builds_repo
-          mkdir -p pr-${{ github.event.pull_request.number }}
-          cp /tmp/apk_stash/$APK_NAME pr-${{ github.event.pull_request.number }}/
+          mkdir -p pr-${{ env.PR_NUMBER }}
+          cp /tmp/apk_stash/$APK_NAME pr-${{ env.PR_NUMBER }}/
           
           git add .
           
@@ -108,20 +127,20 @@ jobs:
             echo "No changes to commit. APK is identical."
             echo "APK_CHANGED=false" >> $GITHUB_ENV
           else
-            git commit -m "Update build for PR #${{ github.event.pull_request.number }}"
+            git commit -m "Update build for PR #${{ env.PR_NUMBER }}"
             git push origin builds
             echo "APK_CHANGED=true" >> $GITHUB_ENV
           fi
 
       - name: Comment Debug APK on PR
-        if: github.event_name == 'pull_request' && env.APK_CHANGED == 'true'
+        if: env.IS_PR_BUILD == 'true' && env.APK_CHANGED == 'true'
         uses: peter-evans/create-or-update-comment@v3
         with:
-          issue-number: ${{ github.event.pull_request.number }}
+          issue-number: ${{ env.PR_NUMBER }}
           body: |
             A debug APK build is available for this pull request.
             
-            [Download ad-silence-${{ env.VERSION_NAME }}-debug APK](https://github.com/${{ github.repository }}/raw/builds/pr-${{ github.event.pull_request.number }}/${{ env.APK_NAME }})
+            [Download ad-silence-${{ env.VERSION_NAME }}-debug APK](https://github.com/${{ github.repository }}/raw/builds/pr-${{ env.PR_NUMBER }}/${{ env.APK_NAME }})
             
             **Certificate SHA-256:** `${{ env.APK_SHA256 }}` (Extracted from build artifact)
             

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "java.configuration.updateBuildConfiguration": "disabled",
+    "java.format.settings.url": "eclipse-formatter.xml"
+}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -68,7 +68,9 @@ dependencies {
     implementation("androidx.concurrent:concurrent-futures-ktx:1.1.0")
     // requirements for android 11 and above to use hibernation end
 
-    implementation 'androidx.mediarouter:mediarouter:1.7.0'
+    // including this increase the final buil size by 600kb, so removing it 
+    // and using native, since targetting android > 5, so it should just work
+    // implementation 'androidx.mediarouter:mediarouter:1.7.0'
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -68,6 +68,8 @@ dependencies {
     implementation("androidx.concurrent:concurrent-futures-ktx:1.1.0")
     // requirements for android 11 and above to use hibernation end
 
+    implementation 'androidx.mediarouter:mediarouter:1.7.0'
+
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/app/src/main/java/bluepie/ad_silence/AdSilenceActivity.kt
+++ b/app/src/main/java/bluepie/ad_silence/AdSilenceActivity.kt
@@ -524,9 +524,29 @@ class AdSilenceActivity : Activity() {
             NOTIFICATION_PERMISSION_REQUEST_CODE -> {
                 if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                     Log.v(TAG, "[permission] permission granted in dialog")
+                    if (preference.isDebugLogEnabled()) {
+                        LogManager.addLifecycleLog(LogEntry(
+                            appName = "AdSilence",
+                            timestamp = System.currentTimeMillis(),
+                            isAd = false,
+                            title = "Permission Granted",
+                            text = "Notification Posting Permission Granted",
+                            subText = "Permission"
+                        ))
+                    }
                     preference.setNotificationPostingPermission(true)
                 } else {
                     Log.v(TAG, "[permission] permission not granted in dialog")
+                    if (preference.isDebugLogEnabled()) {
+                        LogManager.addLifecycleLog(LogEntry(
+                            appName = "AdSilence",
+                            timestamp = System.currentTimeMillis(),
+                            isAd = false,
+                            title = "Permission Denied",
+                            text = "Notification Posting Permission Denied",
+                            subText = "Permission"
+                        ))
+                    }
                     preference.setNotificationPostingPermission(false)
                 }
                 preference.setNotificationPermissionRequested(true)
@@ -758,6 +778,16 @@ class AdSilenceActivity : Activity() {
 
                 dialogView.findViewById<Button>(R.id.btn_delete).setOnClickListener {
                     preference.removeCustomApp(customApp.packageName)
+                    if (preference.isDebugLogEnabled()) {
+                        LogManager.addLog(LogEntry(
+                            appName = "AdSilence",
+                            timestamp = System.currentTimeMillis(),
+                            isAd = false,
+                            title = "Custom App Deleted",
+                            text = "Deleted custom app: ${customApp.name} (${customApp.packageName})",
+                            subText = "Settings"
+                        ))
+                    }
                     populateCustomApps(container, preference)
                     dialog.dismiss()
                 }
@@ -839,6 +869,16 @@ class AdSilenceActivity : Activity() {
             }
 
             preference.addCustomApp(customApp)
+            if (preference.isDebugLogEnabled()) {
+                LogManager.addLog(LogEntry(
+                    appName = "AdSilence",
+                    timestamp = System.currentTimeMillis(),
+                    isAd = false,
+                    title = if (appToEdit != null) "Custom App Updated" else "Custom App Added",
+                    text = "${if (appToEdit != null) "Updated" else "Added"} custom app: $appName ($packageName)",
+                    subText = "Settings"
+                ))
+            }
 
             Toast.makeText(this, if (appToEdit != null) "Custom app updated" else "Custom app added", Toast.LENGTH_SHORT).show()
             onSuccess()
@@ -964,6 +1004,16 @@ class AdSilenceActivity : Activity() {
                         originalVolume = -1
                     }
                     mediaController.setVolumeTo(0, 0)
+                    if (preference.isDebugLogEnabled()) {
+                        LogManager.addLog(LogEntry(
+                            appName = "AdSilence",
+                            timestamp = System.currentTimeMillis(),
+                            isAd = false,
+                            title = "Test Mute",
+                            text = "Muted Cast Stream via MediaController",
+                            subText = "Debug Test"
+                        ))
+                    }
                     Toast.makeText(applicationContext, "Muted Cast (Session)", Toast.LENGTH_SHORT).show()
                 } else {
                     Log.v("AdSilence", "Muting via AudioManager (Fallback)")
@@ -971,6 +1021,16 @@ class AdSilenceActivity : Activity() {
                         audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_MUTE, AudioManager.FLAG_SHOW_UI)
                     } else {
                         audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, 0, AudioManager.FLAG_SHOW_UI)
+                    }
+                    if (preference.isDebugLogEnabled()) {
+                         LogManager.addLog(LogEntry(
+                            appName = "AdSilence",
+                            timestamp = System.currentTimeMillis(),
+                            isAd = false,
+                            title = "Test Mute",
+                            text = "Muted Music Stream via AudioManager (Fallback)",
+                            subText = "Debug Test"
+                        ))
                     }
                     Toast.makeText(applicationContext, "Muted System (Fallback)", Toast.LENGTH_SHORT).show()
                 }
@@ -994,9 +1054,29 @@ class AdSilenceActivity : Activity() {
                     }
 
                     Toast.makeText(applicationContext, "Unmuted Cast (Session)", Toast.LENGTH_SHORT).show()
+                    if (preference.isDebugLogEnabled()) {
+                        LogManager.addLog(LogEntry(
+                            appName = "AdSilence",
+                            timestamp = System.currentTimeMillis(),
+                            isAd = false,
+                            title = "Test Unmute",
+                            text = "Unmuted Cast Stream via MediaController",
+                            subText = "Debug Test"
+                        ))
+                    }
                 } else {
                     Log.v("AdSilence", "Unmuting via AudioManager (Fallback)")
                     audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_UNMUTE, AudioManager.FLAG_SHOW_UI)
+                    if (preference.isDebugLogEnabled()) {
+                         LogManager.addLog(LogEntry(
+                            appName = "AdSilence",
+                            timestamp = System.currentTimeMillis(),
+                            isAd = false,
+                            title = "Test Unmute",
+                            text = "Unmuted Music Stream via AudioManager (Fallback)",
+                            subText = "Debug Test"
+                        ))
+                    }
                     Toast.makeText(applicationContext, "Unmuted System (Fallback)", Toast.LENGTH_SHORT).show()
                 }
             }
@@ -1152,6 +1232,16 @@ class AdSilenceActivity : Activity() {
             isChecked = preference.isMuteEntireDeviceEnabled()
             setOnCheckedChangeListener { _, isChecked ->
                 preference.setMuteEntireDeviceEnabled(isChecked)
+                if (preference.isDebugLogEnabled()) {
+                    LogManager.addLog(LogEntry(
+                        appName = "AdSilence",
+                        timestamp = System.currentTimeMillis(),
+                        isAd = false,
+                        title = "Setting Changed",
+                        text = "Mute Entire Device: $isChecked",
+                        subText = "Settings"
+                    ))
+                }
             }
         }
 
@@ -1159,6 +1249,16 @@ class AdSilenceActivity : Activity() {
             isChecked = preference.isForceMuteNoCheckEnabled()
             setOnCheckedChangeListener { _, isChecked ->
                 preference.setForceMuteNoCheckEnabled(isChecked)
+                if (preference.isDebugLogEnabled()) {
+                    LogManager.addLog(LogEntry(
+                        appName = "AdSilence",
+                        timestamp = System.currentTimeMillis(),
+                        isAd = false,
+                        title = "Setting Changed",
+                        text = "Force Mute: $isChecked",
+                        subText = "Settings"
+                    ))
+                }
             }
         }
 

--- a/app/src/main/java/bluepie/ad_silence/AdSilenceActivity.kt
+++ b/app/src/main/java/bluepie/ad_silence/AdSilenceActivity.kt
@@ -20,12 +20,16 @@ import android.view.View
 import android.widget.*
 import androidx.annotation.RequiresApi
 import androidx.core.app.ActivityCompat
+import androidx.mediarouter.media.MediaControlIntent
+import androidx.mediarouter.media.MediaRouter
+import androidx.mediarouter.media.MediaRouteSelector
+import android.media.AudioDeviceInfo
+import android.media.AudioManager
 
 class AdSilenceActivity : Activity() {
 
     private val TAG = "AdSilence.Activity"
     private val NOTIFICATION_PERMISSION_REQUEST_CODE = 1001
-    private val SHOW_MOCK_DATA = false
     private var aboutDialog: AlertDialog? = null
     private var batteryOptimizationDialog: AlertDialog? = null
     private var debugLogDialog: AlertDialog? = null
@@ -904,25 +908,179 @@ class AdSilenceActivity : Activity() {
             }
         }
 
-        dialogView.findViewById<Button>(R.id.mock_log_btn)?.run {
-            if (SHOW_MOCK_DATA) {
-                this.visibility = View.VISIBLE
-                this.setOnClickListener {
-                    if (preference.isDebugLogEnabled()) {
-                        LogManager.addMockData()
+
+        val testMuteBtn = dialogView.findViewById<Button>(R.id.test_mute_btn)
+        
+        fun updateMuteButtonState() {
+            val audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager
+            val currentMusicVolume = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC)
+            
+            val mediaController = NotificationListener.instance?.getMediaControllerForCasting()
+            var isMuted = currentMusicVolume == 0
+
+            if (mediaController != null) {
+                try {
+                    val playbackInfo = mediaController.playbackInfo
+                    if (playbackInfo != null) {
+                        Log.v(TAG, "Cast PlaybackInfo Volume: ${playbackInfo.currentVolume}, Max: ${playbackInfo.maxVolume}")
+                        // If we have a controller, treat it as the source of truth for "Mute" state if testing for casting
+                        isMuted = playbackInfo.currentVolume == 0 // taking 0 as mute
                     }
+                } catch (e: Exception) {
+                    Log.e(TAG, "Error getting playback info", e)
+                }
+            }
+            
+            testMuteBtn?.text = if (isMuted) "Unmute" else "Mute"
+        }
+        
+        updateMuteButtonState()
+
+        testMuteBtn?.setOnClickListener {
+            val audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager
+            
+            // Try specific MediaSession first
+            val mediaController = NotificationListener.instance?.getMediaControllerForCasting()
+            
+            var isCurrentlyMuted = false
+             if (mediaController != null) {
+                try {
+                     isCurrentlyMuted = mediaController.playbackInfo?.currentVolume == 0
+                } catch (e: Exception) {
+                    isCurrentlyMuted = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC) == 0
                 }
             } else {
-                this.visibility = View.GONE
+                isCurrentlyMuted = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC) == 0
             }
+            
+            if (!isCurrentlyMuted) {
+                // MUTE
+                if (mediaController != null) {
+                    Log.v("AdSilence", "Muting via MediaController")
+                    mediaController.setVolumeTo(0, 0)
+                    Toast.makeText(applicationContext, "Muted Cast (Session)", Toast.LENGTH_SHORT).show()
+                } else {
+                    Log.v("AdSilence", "Muting via AudioManager (Fallback)")
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                        audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_MUTE, AudioManager.FLAG_SHOW_UI)
+                    } else {
+                        audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, 0, AudioManager.FLAG_SHOW_UI)
+                    }
+                    Toast.makeText(applicationContext, "Muted System (Fallback)", Toast.LENGTH_SHORT).show()
+                }
+            } else {
+                // UNMUTE
+                if (mediaController != null) {
+                    Log.v("AdSilence", "Unmuting via MediaController")
+                    // Use adjustVolume(ADJUST_UNMUTE) or set to a reasonable default if 0
+                    try {
+                         // Some apps does not support ADJUST_UNMUTE or it might not work if volume is set to 0 directly.
+                         // try setVolumeTo(DEFAULT) if max > 0, else adjust
+                         val max = mediaController.playbackInfo?.maxVolume ?: 10
+                         val targetVol = if (max > 15) max / 3 else max / 2 // not to blast music, to be adjusted after testing
+                         
+                         mediaController.setVolumeTo(targetVol, 0)
+                         // Also send ADJUST_UNMUTE just in case
+                         // mediaController.adjustVolume(AudioManager.ADJUST_UNMUTE, 0)
+                    } catch (e: Exception) {
+                        Log.e("AdSilence", "Error setting volume, trying adjust", e)
+                        mediaController.adjustVolume(AudioManager.ADJUST_UNMUTE, 0)
+                    }
+
+                    Toast.makeText(applicationContext, "Unmuted Cast (Session)", Toast.LENGTH_SHORT).show()
+                } else {
+                    Log.v("AdSilence", "Unmuting via AudioManager (Fallback)")
+                    audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_UNMUTE, AudioManager.FLAG_SHOW_UI)
+                    Toast.makeText(applicationContext, "Unmuted System (Fallback)", Toast.LENGTH_SHORT).show()
+                }
+            }
+            
+            // Post update to allow volume change to propagate (short delay)
+            testMuteBtn?.postDelayed({ updateMuteButtonState() }, 500)
         }
 
         dialogView.findViewById<Button>(R.id.clear_log_btn)?.setOnClickListener {
             LogManager.clearLogs()
         }
 
+        val castingStatusTextView = dialogView.findViewById<TextView>(R.id.dialog_casting_status_text_view)
+        var mediaRouter: MediaRouter? = null
+        var mediaRouterCallback: MediaRouter.Callback? = null
+
+        try {
+            mediaRouter = MediaRouter.getInstance(applicationContext)
+            val selector = MediaRouteSelector.Builder()
+                .addControlCategory(MediaControlIntent.CATEGORY_REMOTE_PLAYBACK)
+                .addControlCategory(MediaControlIntent.CATEGORY_LIVE_AUDIO)
+                .addControlCategory(MediaControlIntent.CATEGORY_LIVE_VIDEO)
+                .build()
+
+            fun updateCastingStatus() {
+                val route = mediaRouter?.selectedRoute
+                Log.v(TAG, "DebugDialog: Current route: ${route?.name}, type: ${route?.playbackType}, desc: ${route?.description}")
+                
+               // Check AudioManager as well
+                val audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                    val devices = audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS)
+                    for (device in devices) {
+                        Log.v(TAG, "DebugDialog: Audio Device: ${device.productName}, type: ${device.type}")
+                    }
+                }
+
+                if (route != null && route.playbackType == MediaRouter.RouteInfo.PLAYBACK_TYPE_REMOTE) {
+                    castingStatusTextView?.text = "Casting to: ${route.name}"
+                    castingStatusTextView?.visibility = View.VISIBLE
+                } else {
+                    // Fallback: Check for system notification
+                    val listenerInstance = NotificationListener.instance
+                    if (listenerInstance == null) {
+                        Log.v(TAG, "DebugDialog: NotificationListener instance is null. Service likely not running or permission missing.")
+                        castingStatusTextView?.text = "Casting: Service Not Connected (Check Permissions)"
+                        castingStatusTextView?.visibility = View.VISIBLE
+                    } else {
+                        val notificationCastingStatus = listenerInstance.checkForCastingNotification()
+                        if (notificationCastingStatus != null) {
+                            castingStatusTextView?.text = "Casting (Sys): $notificationCastingStatus"
+                            castingStatusTextView?.visibility = View.VISIBLE
+                        } else if (route != null) {
+                            castingStatusTextView?.text = "Not Casting (Route: ${route.name})"
+                            castingStatusTextView?.visibility = View.VISIBLE
+                        } else {
+                            castingStatusTextView?.text = "Casting: Not Connected"
+                            castingStatusTextView?.visibility = View.VISIBLE
+                        }
+                    }
+                }
+            }
+            
+            updateCastingStatus()
+
+            mediaRouterCallback = object : MediaRouter.Callback() {
+                override fun onRouteSelected(router: MediaRouter, route: MediaRouter.RouteInfo) {
+                    updateCastingStatus()
+                }
+                override fun onRouteUnselected(router: MediaRouter, route: MediaRouter.RouteInfo) {
+                    updateCastingStatus()
+                }
+                override fun onRouteChanged(router: MediaRouter, route: MediaRouter.RouteInfo) {
+                    updateCastingStatus()
+                }
+            }
+            
+            mediaRouter?.addCallback(selector, mediaRouterCallback, MediaRouter.CALLBACK_FLAG_REQUEST_DISCOVERY)
+
+        } catch (e: Exception) {
+            Log.e(TAG, "Error initializing MediaRouter for debug dialog", e)
+            castingStatusTextView?.text = "Casting: Error accessing MediaRouter"
+            castingStatusTextView?.visibility = View.VISIBLE
+        }
+
         dialog.setOnDismissListener {
             LogManager.removeListener(logListener)
+            mediaRouterCallback?.let {
+                 mediaRouter?.removeCallback(it)
+            }
         }
 
         dialog.window?.setBackgroundDrawableResource(android.R.color.transparent)

--- a/app/src/main/java/bluepie/ad_silence/AdSilenceActivity.kt
+++ b/app/src/main/java/bluepie/ad_silence/AdSilenceActivity.kt
@@ -20,9 +20,7 @@ import android.view.View
 import android.widget.*
 import androidx.annotation.RequiresApi
 import androidx.core.app.ActivityCompat
-import androidx.mediarouter.media.MediaControlIntent
-import androidx.mediarouter.media.MediaRouter
-import androidx.mediarouter.media.MediaRouteSelector
+import android.media.MediaRouter
 import android.media.AudioDeviceInfo
 import android.media.AudioManager
 
@@ -936,6 +934,8 @@ class AdSilenceActivity : Activity() {
         
         updateMuteButtonState()
 
+        var originalVolume = -1
+
         testMuteBtn?.setOnClickListener {
             val audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager
             
@@ -945,6 +945,7 @@ class AdSilenceActivity : Activity() {
             var isCurrentlyMuted = false
              if (mediaController != null) {
                 try {
+                     // 0 is technically muted, but some devices have min volume.
                      isCurrentlyMuted = mediaController.playbackInfo?.currentVolume == 0
                 } catch (e: Exception) {
                     isCurrentlyMuted = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC) == 0
@@ -957,6 +958,11 @@ class AdSilenceActivity : Activity() {
                 // MUTE
                 if (mediaController != null) {
                     Log.v("AdSilence", "Muting via MediaController")
+                    try {
+                        originalVolume = mediaController.playbackInfo?.currentVolume ?: -1
+                    } catch (e: Exception) {
+                        originalVolume = -1
+                    }
                     mediaController.setVolumeTo(0, 0)
                     Toast.makeText(applicationContext, "Muted Cast (Session)", Toast.LENGTH_SHORT).show()
                 } else {
@@ -972,16 +978,16 @@ class AdSilenceActivity : Activity() {
                 // UNMUTE
                 if (mediaController != null) {
                     Log.v("AdSilence", "Unmuting via MediaController")
-                    // Use adjustVolume(ADJUST_UNMUTE) or set to a reasonable default if 0
                     try {
-                         // Some apps does not support ADJUST_UNMUTE or it might not work if volume is set to 0 directly.
-                         // try setVolumeTo(DEFAULT) if max > 0, else adjust
-                         val max = mediaController.playbackInfo?.maxVolume ?: 10
-                         val targetVol = if (max > 15) max / 3 else max / 2 // not to blast music, to be adjusted after testing
-                         
-                         mediaController.setVolumeTo(targetVol, 0)
-                         // Also send ADJUST_UNMUTE just in case
-                         // mediaController.adjustVolume(AudioManager.ADJUST_UNMUTE, 0)
+                         if (originalVolume != -1) {
+                             mediaController.setVolumeTo(originalVolume, 0)
+                             originalVolume = -1 // Reset
+                         } else {
+                             // Fallback if we didn't capture original volume
+                             val max = mediaController.playbackInfo?.maxVolume ?: 10
+                             val targetVol = if (max > 15) max / 3 else max / 2 
+                             mediaController.setVolumeTo(targetVol, 0)
+                         }
                     } catch (e: Exception) {
                         Log.e("AdSilence", "Error setting volume, trying adjust", e)
                         mediaController.adjustVolume(AudioManager.ADJUST_UNMUTE, 0)
@@ -1008,15 +1014,10 @@ class AdSilenceActivity : Activity() {
         var mediaRouterCallback: MediaRouter.Callback? = null
 
         try {
-            mediaRouter = MediaRouter.getInstance(applicationContext)
-            val selector = MediaRouteSelector.Builder()
-                .addControlCategory(MediaControlIntent.CATEGORY_REMOTE_PLAYBACK)
-                .addControlCategory(MediaControlIntent.CATEGORY_LIVE_AUDIO)
-                .addControlCategory(MediaControlIntent.CATEGORY_LIVE_VIDEO)
-                .build()
+            mediaRouter = applicationContext.getSystemService(Context.MEDIA_ROUTER_SERVICE) as MediaRouter
 
             fun updateCastingStatus() {
-                val route = mediaRouter?.selectedRoute
+                val route = mediaRouter?.getSelectedRoute(MediaRouter.ROUTE_TYPE_LIVE_AUDIO)
                 Log.v(TAG, "DebugDialog: Current route: ${route?.name}, type: ${route?.playbackType}, desc: ${route?.description}")
                 
                // Check AudioManager as well
@@ -1056,11 +1057,11 @@ class AdSilenceActivity : Activity() {
             
             updateCastingStatus()
 
-            mediaRouterCallback = object : MediaRouter.Callback() {
-                override fun onRouteSelected(router: MediaRouter, route: MediaRouter.RouteInfo) {
+            mediaRouterCallback = object : MediaRouter.SimpleCallback() {
+                override fun onRouteSelected(router: MediaRouter, type: Int, route: MediaRouter.RouteInfo) {
                     updateCastingStatus()
                 }
-                override fun onRouteUnselected(router: MediaRouter, route: MediaRouter.RouteInfo) {
+                override fun onRouteUnselected(router: MediaRouter, type: Int, route: MediaRouter.RouteInfo) {
                     updateCastingStatus()
                 }
                 override fun onRouteChanged(router: MediaRouter, route: MediaRouter.RouteInfo) {
@@ -1068,7 +1069,7 @@ class AdSilenceActivity : Activity() {
                 }
             }
             
-            mediaRouter?.addCallback(selector, mediaRouterCallback, MediaRouter.CALLBACK_FLAG_REQUEST_DISCOVERY)
+            mediaRouter?.addCallback(MediaRouter.ROUTE_TYPE_LIVE_AUDIO, mediaRouterCallback, MediaRouter.CALLBACK_FLAG_PERFORM_ACTIVE_SCAN)
 
         } catch (e: Exception) {
             Log.e(TAG, "Error initializing MediaRouter for debug dialog", e)

--- a/app/src/main/java/bluepie/ad_silence/CastMuteManager.kt
+++ b/app/src/main/java/bluepie/ad_silence/CastMuteManager.kt
@@ -15,6 +15,16 @@ class CastMuteManager(private val context: Context) {
         val controller = notificationListener.getMediaControllerForCasting()
         if (controller != null) {
             Log.v(TAG, "Found MediaController, attempting to mute...")
+            if (Preference(context).isDebugLogEnabled()) {
+                LogManager.addLifecycleLog(LogEntry(
+                    appName = "AdSilence",
+                    timestamp = System.currentTimeMillis(),
+                    isAd = true,
+                    title = "Casting Mute Attempt",
+                    text = "Found MediaController, attempting to mute...",
+                    subText = "Cast Manager"
+                ))
+            }
             try {
                 // Save volume only if not already muted by CasteMuteManager
                 // a bug where subsequence mute, saves as 0.
@@ -23,6 +33,16 @@ class CastMuteManager(private val context: Context) {
                     if (current != null) {
                         originalVolume = current
                         Log.v(TAG, "Saved cast volume: $originalVolume")
+                        if (Preference(context).isDebugLogEnabled()) {
+                            LogManager.addLifecycleLog(LogEntry(
+                                appName = "AdSilence",
+                                timestamp = System.currentTimeMillis(),
+                                isAd = true,
+                                title = "Saved Cast Volume",
+                                text = "Saved cast volume: $originalVolume",
+                                subText = "Cast Manager"
+                            ))
+                        }
                     }
                 } else {
                     Log.v(TAG, "Already muted by manager, keeping original volume: $originalVolume")
@@ -30,9 +50,40 @@ class CastMuteManager(private val context: Context) {
                 
                 controller.setVolumeTo(0, 0)
                 isMutedByManager = true
+                if (Preference(context).isDebugLogEnabled()) {
+                    LogManager.addLifecycleLog(LogEntry(
+                        appName = "AdSilence",
+                        timestamp = System.currentTimeMillis(),
+                        isAd = true,
+                        title = "Casting Muted",
+                        text = "Successfully muted via MediaController",
+                        subText = "Cast Manager"
+                    ))
+                }
                 return true
             } catch (e: Exception) {
                 Log.e(TAG, "Error muting via MediaController", e)
+                if (Preference(context).isDebugLogEnabled()) {
+                    LogManager.addLifecycleLog(LogEntry(
+                        appName = "AdSilence",
+                        timestamp = System.currentTimeMillis(),
+                        isAd = true,
+                        title = "Casting Mute Error",
+                        text = "Error muting via MediaController: ${e.message}",
+                        subText = "Cast Manager"
+                    ))
+                }
+            }
+        } else {
+             if (Preference(context).isDebugLogEnabled()) {
+                LogManager.addLifecycleLog(LogEntry(
+                    appName = "AdSilence",
+                    timestamp = System.currentTimeMillis(),
+                    isAd = true,
+                    title = "Casting Mute Failed",
+                    text = "No MediaController found for casting",
+                    subText = "Cast Manager"
+                ))
             }
         }
         return false
@@ -46,27 +97,97 @@ class CastMuteManager(private val context: Context) {
         val controller = notificationListener.getMediaControllerForCasting()
         if (controller != null) {
             Log.v(TAG, "Found MediaController, attempting to unmute...")
+             if (Preference(context).isDebugLogEnabled()) {
+                LogManager.addLifecycleLog(LogEntry(
+                    appName = "AdSilence",
+                    timestamp = System.currentTimeMillis(),
+                    isAd = false,
+                    title = "Casting Unmute Attempt",
+                    text = "Found MediaController, attempting to unmute...",
+                    subText = "Cast Manager"
+                ))
+            }
             try {
                 if (originalVolume != -1) {
                      Log.v(TAG, "Restoring cast volume to $originalVolume")
                      controller.setVolumeTo(originalVolume, 0)
+                     if (Preference(context).isDebugLogEnabled()) {
+                        LogManager.addLifecycleLog(LogEntry(
+                            appName = "AdSilence",
+                            timestamp = System.currentTimeMillis(),
+                            isAd = false,
+                            title = "Restoring Cast Volume",
+                            text = "Restoring cast volume to $originalVolume",
+                            subText = "Cast Manager"
+                        ))
+                    }
                      originalVolume = -1
                 } else {
                      // Fallback if missed saving
                      Log.v(TAG, "No saved volume, adjusting unmute")
                      controller.adjustVolume(AudioManager.ADJUST_UNMUTE, 0)
+                     if (Preference(context).isDebugLogEnabled()) {
+                        LogManager.addLifecycleLog(LogEntry(
+                            appName = "AdSilence",
+                            timestamp = System.currentTimeMillis(),
+                            isAd = false,
+                            title = "Casting Unmute Fallback",
+                            text = "No saved volume, using adjustVolume UNMUTE",
+                            subText = "Cast Manager"
+                        ))
+                    }
                 }
                 
                 isMutedByManager = false
+                if (Preference(context).isDebugLogEnabled()) {
+                    LogManager.addLifecycleLog(LogEntry(
+                        appName = "AdSilence",
+                        timestamp = System.currentTimeMillis(),
+                        isAd = false,
+                        title = "Casting Unmuted",
+                        text = "Successfully unmuted via MediaController",
+                        subText = "Cast Manager"
+                    ))
+                }
                 return true
             } catch (e: Exception) {
                 Log.e(TAG, "Error unmuting via MediaController", e)
+                 if (Preference(context).isDebugLogEnabled()) {
+                    LogManager.addLifecycleLog(LogEntry(
+                        appName = "AdSilence",
+                        timestamp = System.currentTimeMillis(),
+                        isAd = false,
+                        title = "Casting Unmute Error",
+                        text = "Error unmuting via MediaController: ${e.message}",
+                        subText = "Cast Manager"
+                    ))
+                }
                 try {
                      controller.adjustVolume(AudioManager.ADJUST_UNMUTE, 0)
                      isMutedByManager = false
+                      if (Preference(context).isDebugLogEnabled()) {
+                        LogManager.addLifecycleLog(LogEntry(
+                            appName = "AdSilence",
+                            timestamp = System.currentTimeMillis(),
+                            isAd = false,
+                            title = "Casting Unmute Fallback Retry",
+                            text = "Attempted fallback adjustVolume UNMUTE after error",
+                            subText = "Cast Manager"
+                        ))
+                    }
                      return true
                 } catch (e2: Exception) {
                      Log.e(TAG, "Fallback also failed", e2)
+                      if (Preference(context).isDebugLogEnabled()) {
+                        LogManager.addLifecycleLog(LogEntry(
+                            appName = "AdSilence",
+                            timestamp = System.currentTimeMillis(),
+                            isAd = false,
+                            title = "Casting Unmute Fatal Error",
+                            text = "Fallback also failed: ${e2.message}",
+                            subText = "Cast Manager"
+                        ))
+                    }
                 }
             }
         }

--- a/app/src/main/java/bluepie/ad_silence/CastMuteManager.kt
+++ b/app/src/main/java/bluepie/ad_silence/CastMuteManager.kt
@@ -9,11 +9,25 @@ class CastMuteManager(private val context: Context) {
     private val TAG = "CastMuteManager"
     private var isMutedByManager = false
 
+    private var originalVolume = -1
+
     fun tryMute(notificationListener: NotificationListener): Boolean {
         val controller = notificationListener.getMediaControllerForCasting()
         if (controller != null) {
             Log.v(TAG, "Found MediaController, attempting to mute...")
             try {
+                // Save volume only if not already muted by CasteMuteManager
+                // a bug where subsequence mute, saves as 0.
+                if (!isMutedByManager) {
+                    val current = controller.playbackInfo?.currentVolume
+                    if (current != null) {
+                        originalVolume = current
+                        Log.v(TAG, "Saved cast volume: $originalVolume")
+                    }
+                } else {
+                    Log.v(TAG, "Already muted by manager, keeping original volume: $originalVolume")
+                }
+                
                 controller.setVolumeTo(0, 0)
                 isMutedByManager = true
                 return true
@@ -33,17 +47,20 @@ class CastMuteManager(private val context: Context) {
         if (controller != null) {
             Log.v(TAG, "Found MediaController, attempting to unmute...")
             try {
-                // Some apps does not support ADJUST_UNMUTE or it might not work if volume is set to 0 directly.
-                val max = controller.playbackInfo?.maxVolume ?: 10
-                val targetVol = if (max > 15) max / 3 else max / 2 // Default to reasonable volume
-                
-                Log.v(TAG, "Unmuting: Setting volume to $targetVol (Max: $max)")
-                controller.setVolumeTo(targetVol, 0)
+                if (originalVolume != -1) {
+                     Log.v(TAG, "Restoring cast volume to $originalVolume")
+                     controller.setVolumeTo(originalVolume, 0)
+                     originalVolume = -1
+                } else {
+                     // Fallback if missed saving
+                     Log.v(TAG, "No saved volume, adjusting unmute")
+                     controller.adjustVolume(AudioManager.ADJUST_UNMUTE, 0)
+                }
                 
                 isMutedByManager = false
                 return true
             } catch (e: Exception) {
-                Log.e(TAG, "Error unmuting via MediaController, trying adjust fallback", e)
+                Log.e(TAG, "Error unmuting via MediaController", e)
                 try {
                      controller.adjustVolume(AudioManager.ADJUST_UNMUTE, 0)
                      isMutedByManager = false

--- a/app/src/main/java/bluepie/ad_silence/CastMuteManager.kt
+++ b/app/src/main/java/bluepie/ad_silence/CastMuteManager.kt
@@ -1,0 +1,63 @@
+package bluepie.ad_silence
+
+import android.content.Context
+import android.media.AudioManager
+import android.media.session.MediaController
+import android.util.Log
+
+class CastMuteManager(private val context: Context) {
+    private val TAG = "CastMuteManager"
+    private var isMutedByManager = false
+
+    fun tryMute(notificationListener: NotificationListener): Boolean {
+        val controller = notificationListener.getMediaControllerForCasting()
+        if (controller != null) {
+            Log.v(TAG, "Found MediaController, attempting to mute...")
+            try {
+                controller.setVolumeTo(0, 0)
+                isMutedByManager = true
+                return true
+            } catch (e: Exception) {
+                Log.e(TAG, "Error muting via MediaController", e)
+            }
+        }
+        return false
+    }
+
+    fun tryUnmute(notificationListener: NotificationListener): Boolean {
+        if (!isMutedByManager) {
+            return false
+        }
+
+        val controller = notificationListener.getMediaControllerForCasting()
+        if (controller != null) {
+            Log.v(TAG, "Found MediaController, attempting to unmute...")
+            try {
+                // Some apps does not support ADJUST_UNMUTE or it might not work if volume is set to 0 directly.
+                val max = controller.playbackInfo?.maxVolume ?: 10
+                val targetVol = if (max > 15) max / 3 else max / 2 // Default to reasonable volume
+                
+                Log.v(TAG, "Unmuting: Setting volume to $targetVol (Max: $max)")
+                controller.setVolumeTo(targetVol, 0)
+                
+                isMutedByManager = false
+                return true
+            } catch (e: Exception) {
+                Log.e(TAG, "Error unmuting via MediaController, trying adjust fallback", e)
+                try {
+                     controller.adjustVolume(AudioManager.ADJUST_UNMUTE, 0)
+                     isMutedByManager = false
+                     return true
+                } catch (e2: Exception) {
+                     Log.e(TAG, "Fallback also failed", e2)
+                }
+            }
+        }
+        
+        // Even if controller is null (session might get lost), reset flag
+        isMutedByManager = false
+        return false
+    }
+    
+    fun isMuted() = isMutedByManager
+}

--- a/app/src/main/java/bluepie/ad_silence/Hibernation.kt
+++ b/app/src/main/java/bluepie/ad_silence/Hibernation.kt
@@ -42,6 +42,16 @@ class Hibernation(private val context: Context, private val activity: AdSilenceA
 
             UnusedAppRestrictionsConstants.DISABLED -> {
                 Log.v(TAG, "[hibernation] user has disabled hibernation for the app")
+                 if (Preference(context).isDebugLogEnabled()) {
+                    LogManager.addLog(LogEntry(
+                        appName = "AdSilence",
+                        timestamp = System.currentTimeMillis(),
+                        isAd = false,
+                        title = "Hibernation Status",
+                        text = "User has disabled hibernation for the app (Good)",
+                        subText = "System"
+                    ))
+                }
             }
 
             // Restrictions don't apply to your app on this device.
@@ -51,7 +61,19 @@ class Hibernation(private val context: Context, private val activity: AdSilenceA
 
             // If the user doesn't start your app for a few months, the system will
             // place restrictions on it. See the API_* constants for details.
-            UnusedAppRestrictionsConstants.API_30_BACKPORT, UnusedAppRestrictionsConstants.API_30, UnusedAppRestrictionsConstants.API_31 -> this.handleRestrictions(appRestrictionsStatus)
+            UnusedAppRestrictionsConstants.API_30_BACKPORT, UnusedAppRestrictionsConstants.API_30, UnusedAppRestrictionsConstants.API_31 -> {
+                 if (Preference(context).isDebugLogEnabled()) {
+                    LogManager.addLog(LogEntry(
+                        appName = "AdSilence",
+                        timestamp = System.currentTimeMillis(),
+                        isAd = false,
+                        title = "Hibernation Status",
+                        text = "Hibernation restrictions might apply (API 30+)",
+                        subText = "System"
+                    ))
+                }
+                this.handleRestrictions(appRestrictionsStatus)
+            }
         }
     }
 

--- a/app/src/main/java/bluepie/ad_silence/LogManager.kt
+++ b/app/src/main/java/bluepie/ad_silence/LogManager.kt
@@ -63,18 +63,7 @@ object LogManager {
         notifyListeners()
     }
 
-    fun addMockData() {
-        val mockLogs = listOf(
-            LogEntry("Spotify", System.currentTimeMillis(), true, "Song Title", "Artist Name", "Album Info", "Artist Name"),
-            LogEntry("YouTube", System.currentTimeMillis() - 60000, false, "Video Title", "Channel Name", "Description", null),
-            LogEntry("Pandora", System.currentTimeMillis() - 120000, true, "Ad Title", "Ad Text", "Sponsored", "Ad Text"),
-            LogEntry("System", System.currentTimeMillis() - 180000, false, "Service Started", "AdSilence", "Background Service", null)
-        )
-        synchronized(logs) {
-            logs.addAll(0, mockLogs)
-        }
-        notifyListeners()
-    }
+
 
     fun addListener(listener: () -> Unit) {
         listeners.add(listener)

--- a/app/src/main/java/bluepie/ad_silence/NotificationListener.kt
+++ b/app/src/main/java/bluepie/ad_silence/NotificationListener.kt
@@ -312,6 +312,16 @@ class NotificationListener : NotificationListenerService() {
                                         if (castController != null) {
                                             isCasting = true
                                             Log.v(TAG, "Casting detected via Notification Fallback")
+                                            if (isDebugEnabled) {
+                                                LogManager.addLifecycleLog(LogEntry(
+                                                    appName = "AdSilence",
+                                                    timestamp = System.currentTimeMillis(),
+                                                    isAd = true,
+                                                    title = "Casting Detected",
+                                                    text = "Casting session detected via Notification Fallback",
+                                                    subText = "Detection"
+                                                ))
+                                            }
                                         }
                                     }
                                     
@@ -322,6 +332,16 @@ class NotificationListener : NotificationListenerService() {
                                         if (isCasting) {
                                             if (route != null && route.playbackType == MediaRouter.RouteInfo.PLAYBACK_TYPE_REMOTE) {
                                                 Log.v(TAG, "Casting detected on route: ${route.name}. Muting remote volume.")
+                                                if (isDebugEnabled) {
+                                                    LogManager.addLifecycleLog(LogEntry(
+                                                        appName = "AdSilence",
+                                                        timestamp = System.currentTimeMillis(),
+                                                        isAd = true,
+                                                        title = "Casting Mute (Remote)",
+                                                        text = "Muting remote volume on route: ${route.name}",
+                                                        subText = "Action"
+                                                    ))
+                                                }
                                                 handler.post {
                                                     originalRemoteVolume = route.volume
                                                     route.requestSetVolume(0)

--- a/app/src/main/java/bluepie/ad_silence/NotificationListener.kt
+++ b/app/src/main/java/bluepie/ad_silence/NotificationListener.kt
@@ -23,6 +23,7 @@ class NotificationListener : NotificationListenerService() {
     private var muteCount: Int = 0
     private val handler = Handler(Looper.getMainLooper())
     private var unmuteRunnable: Runnable? = null
+    private lateinit var castMuteManager: CastMuteManager
     
     // MediaRouter related variables
     private var mediaRouter: MediaRouter? = null
@@ -55,9 +56,11 @@ class NotificationListener : NotificationListenerService() {
 
     override fun onCreate() {
         super.onCreate()
+        instance = this
         startTime = System.currentTimeMillis()
         audioManager = applicationContext.getSystemService(AUDIO_SERVICE) as AudioManager
         appNotificationHelper = AppNotificationHelper(applicationContext)
+        castMuteManager = CastMuteManager(applicationContext)
 
         // Initialize MediaRouter on main thread
         handler.post {
@@ -229,6 +232,7 @@ class NotificationListener : NotificationListenerService() {
 
     override fun onDestroy() {
         super.onDestroy()
+        instance = null
         // Cleanup MediaRouter
         handler.post {
             try {
@@ -306,26 +310,24 @@ class NotificationListener : NotificationListenerService() {
                                     
                                     // Check for casting
                                     val route = currentRoute
-                                    // DEBUG: Force isCasting to true to test logic flow
-                                    val isCasting = true // route != null && route.playbackType == MediaRouter.RouteInfo.PLAYBACK_TYPE_REMOTE
+                                    val isCasting = route != null && route.playbackType == MediaRouter.RouteInfo.PLAYBACK_TYPE_REMOTE
                                     
                                     if (!isMuted || !isMusicStreamMuted) {
                                         Log.v(TAG, "'MusicStream' muted? -> $isMusicStreamMuted")
                                         Log.v(TAG, "Ad detected muting, state-> $isMuted to ${!isMuted}, currentPackage: $currentPackage")
                                         
-                                        // DEBUG: Simplified check for null route to prevent crash during mock
-                                        if (isCasting && (route == null || route.volumeHandling == MediaRouter.RouteInfo.PLAYBACK_VOLUME_VARIABLE)) {
-                                            Log.v(TAG, "Casting detected on route: ${route?.name ?: "MOCK_ROUTE"}. Muting remote volume.")
+                                        if (isCasting && (route != null && route.volumeHandling == MediaRouter.RouteInfo.PLAYBACK_VOLUME_VARIABLE)) {
+                                            Log.v(TAG, "Casting detected on route: ${route.name}. Muting remote volume.")
                                             handler.post {
-                                                if (route != null) {
-                                                    originalRemoteVolume = route.volume
-                                                    route.requestSetVolume(0)
-                                                } else {
-                                                    Log.v(TAG, "MOCK: Would set remote volume to 0")
-                                                }
+                                                originalRemoteVolume = route.volume
+                                                route.requestSetVolume(0)
                                             }
                                         } else {
-                                            this.mute(audioManager, appNotificationHelper, preference)
+                                            if (castMuteManager.tryMute(this@NotificationListener)) {
+                                                Log.v(TAG, "Muted via CastMuteManager")
+                                            } else {
+                                                this.mute(audioManager, appNotificationHelper, preference)
+                                            }
                                         }
                                         
                                         if (isDebugEnabled) {
@@ -357,21 +359,43 @@ class NotificationListener : NotificationListenerService() {
                                                 if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
                                                     Log.v(TAG, "Not an ad, Unmuting, < M")
                                                     // for android 5 & 5.1, unmute has to be done, count x mutedCount
-                                                    // DEBUG: Force isCasting to true
-                                                    val isCasting = true // route != null && route.playbackType == MediaRouter.RouteInfo.PLAYBACK_TYPE_REMOTE
-                                                    
+                                                    val isCasting = route != null && route.playbackType == MediaRouter.RouteInfo.PLAYBACK_TYPE_REMOTE
+
                                                     while (muteCount > 0) {
-                                                        // DEBUG: Handle null route safely
-                                                        if (isCasting && (route == null || (route.volumeHandling == MediaRouter.RouteInfo.PLAYBACK_VOLUME_VARIABLE && originalRemoteVolume != -1))) {
+                                                        if (isCasting && (route != null && route.volumeHandling == MediaRouter.RouteInfo.PLAYBACK_VOLUME_VARIABLE && originalRemoteVolume != -1)) {
                                                              Log.v(TAG, "Restoring remote volume to $originalRemoteVolume")
                                                              handler.post {
-                                                                 if (route != null) {
-                                                                     route.requestSetVolume(originalRemoteVolume)
-                                                                 } else {
-                                                                     Log.v(TAG, "MOCK: Would restore remote volume")
-                                                                 }
+                                                                 route.requestSetVolume(originalRemoteVolume)
                                                                  originalRemoteVolume = -1
                                                              }
+                                                        } else {
+                                                            if (castMuteManager.tryUnmute(this@NotificationListener)) {
+                                                                Log.v(TAG, "Unmuted via CastMuteManager (< M)")
+                                                            } else {
+                                                                this@run.unmute(
+                                                                    audioManager,
+                                                                    appNotificationHelper,
+                                                                    currentPackage,
+                                                                    preference
+                                                                )
+                                                            }
+                                                        }
+                                                        muteCount--
+                                                    }
+                                                    isMuted = false
+                                                } else {
+                                                    Log.v(TAG, "Not an ad, Unmuting, > M")
+                                                    val isCasting = route != null && route.playbackType == MediaRouter.RouteInfo.PLAYBACK_TYPE_REMOTE
+
+                                                    if (isCasting && (route != null && route.volumeHandling == MediaRouter.RouteInfo.PLAYBACK_VOLUME_VARIABLE && originalRemoteVolume != -1)) {
+                                                         Log.v(TAG, "Restoring remote volume to $originalRemoteVolume")
+                                                         handler.post {
+                                                             route.requestSetVolume(originalRemoteVolume)
+                                                             originalRemoteVolume = -1
+                                                         }
+                                                    } else {
+                                                        if (castMuteManager.tryUnmute(this@NotificationListener)) {
+                                                            Log.v(TAG, "Unmuted via CastMuteManager (> M)")
                                                         } else {
                                                             this@run.unmute(
                                                                 audioManager,
@@ -380,32 +404,6 @@ class NotificationListener : NotificationListenerService() {
                                                                 preference
                                                             )
                                                         }
-                                                        muteCount--
-                                                    }
-                                                    isMuted = false
-                                                } else {
-                                                    Log.v(TAG, "Not an ad, Unmuting, > M")
-                                                    // DEBUG: Force isCasting to true
-                                                    val isCasting = true // route != null && route.playbackType == MediaRouter.RouteInfo.PLAYBACK_TYPE_REMOTE
-                                                    
-                                                    // DEBUG: Handle null route safely
-                                                    if (isCasting && (route == null || (route.volumeHandling == MediaRouter.RouteInfo.PLAYBACK_VOLUME_VARIABLE && originalRemoteVolume != -1))) {
-                                                         Log.v(TAG, "Restoring remote volume to $originalRemoteVolume")
-                                                         handler.post {
-                                                             if (route != null) {
-                                                                 route.requestSetVolume(originalRemoteVolume)
-                                                             } else {
-                                                                 Log.v(TAG, "MOCK: Would restore remote volume")
-                                                             }
-                                                             originalRemoteVolume = -1
-                                                         }
-                                                    } else {
-                                                        this@run.unmute(
-                                                            audioManager,
-                                                            appNotificationHelper,
-                                                            currentPackage,
-                                                            preference
-                                                        )
                                                     }
                                                     isMuted = false
                                                 }
@@ -451,5 +449,59 @@ class NotificationListener : NotificationListenerService() {
     }
     companion object {
         @Volatile var startTime: Long = 0
+        @Volatile var instance: NotificationListener? = null
+    }
+
+    fun checkForCastingNotification(): String? {
+        try {
+            val notifications = activeNotifications
+            for (sbn in notifications) {
+                val extras = sbn.notification.extras
+                val title = extras.getCharSequence(android.app.Notification.EXTRA_TITLE)?.toString()
+                val text = extras.getCharSequence(android.app.Notification.EXTRA_TEXT)?.toString() ?: ""
+                val subText = extras.getCharSequence(android.app.Notification.EXTRA_SUB_TEXT)?.toString() ?: ""
+                
+                // "Casting to..." (GMS & others)
+                if (title?.contains("Casting to", ignoreCase = true) == true || 
+                    text.contains("Casting to", ignoreCase = true) == true) {
+                    return "$title"
+                }
+                
+                // "Listening on..." (Spotify)
+                if (subText.contains("Listening on", ignoreCase = true) == true) {
+                    return "Casting: $subText" // e.g. "Casting: Listening on Kitchen Speaker"
+                }
+
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error checking for casting notification", e)
+        }
+        return null
+    }
+    fun getMediaControllerForCasting(): android.media.session.MediaController? {
+        try {
+            val notifications = activeNotifications
+            for (sbn in notifications) {
+                val extras = sbn.notification.extras
+                val token = extras.getParcelable<android.media.session.MediaSession.Token>(android.app.Notification.EXTRA_MEDIA_SESSION)
+                
+                if (token != null) {
+                    val subText = extras.getCharSequence(android.app.Notification.EXTRA_SUB_TEXT)?.toString() ?: ""
+                    
+                    // Check if it's likely the casting session
+                val isCastingText = subText.contains("Listening on", ignoreCase = true) || 
+                                  subText.contains("Casting to", ignoreCase = true) ||
+                                  extras.getCharSequence(android.app.Notification.EXTRA_TITLE)?.toString()?.contains("Casting to", ignoreCase = true) == true
+
+                if (isCastingText) {
+                     Log.v(TAG, "Found MediaSession for casting: ${sbn.packageName}")
+                     return android.media.session.MediaController(applicationContext, token)
+                }
+            }
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error getting MediaController", e)
+        }
+        return null
     }
 }

--- a/app/src/main/java/bluepie/ad_silence/NotificationListener.kt
+++ b/app/src/main/java/bluepie/ad_silence/NotificationListener.kt
@@ -10,6 +10,9 @@ import android.service.notification.StatusBarNotification
 import android.util.Log
 import android.os.Handler
 import android.os.Looper
+import androidx.mediarouter.media.MediaRouter
+import androidx.mediarouter.media.MediaRouteSelector
+import androidx.mediarouter.media.MediaControlIntent
 
 @SuppressLint("LongLogTag")
 class NotificationListener : NotificationListenerService() {
@@ -20,12 +23,57 @@ class NotificationListener : NotificationListenerService() {
     private var muteCount: Int = 0
     private val handler = Handler(Looper.getMainLooper())
     private var unmuteRunnable: Runnable? = null
+    
+    // MediaRouter related variables
+    private var mediaRouter: MediaRouter? = null
+    private var currentRoute: MediaRouter.RouteInfo? = null
+    private var originalRemoteVolume: Int = -1
+    private val mediaRouterCallback = object : MediaRouter.Callback() {
+        override fun onRouteSelected(router: MediaRouter, route: MediaRouter.RouteInfo) {
+            currentRoute = route
+            Log.v(TAG, "MediaRouter: Route selected: ${route.name}, type: ${route.playbackType}")
+            // If route changes while muted, reset the original volume tracking
+            if (originalRemoteVolume != -1) {
+                originalRemoteVolume = -1
+                // potentially we could try to unmute the old route if we had a reference, but simplified for now
+            }
+        }
+
+        override fun onRouteUnselected(router: MediaRouter, route: MediaRouter.RouteInfo) {
+            Log.v(TAG, "MediaRouter: Route unselected: ${route.name}")
+            if (currentRoute == route) {
+                currentRoute = null
+            }
+        }
+
+        override fun onRouteChanged(router: MediaRouter, route: MediaRouter.RouteInfo) {
+            if (currentRoute == route) {
+                Log.v(TAG, "MediaRouter: Route changed: ${route.name}, volume: ${route.volume}")
+            }
+        }
+    }
 
     override fun onCreate() {
         super.onCreate()
         startTime = System.currentTimeMillis()
         audioManager = applicationContext.getSystemService(AUDIO_SERVICE) as AudioManager
         appNotificationHelper = AppNotificationHelper(applicationContext)
+
+        // Initialize MediaRouter on main thread
+        handler.post {
+            try {
+                mediaRouter = MediaRouter.getInstance(applicationContext)
+                val selector = MediaRouteSelector.Builder()
+                    .addControlCategory(MediaControlIntent.CATEGORY_REMOTE_PLAYBACK)
+                    .addControlCategory(MediaControlIntent.CATEGORY_LIVE_AUDIO)
+                    .build()
+                mediaRouter?.addCallback(selector, mediaRouterCallback, MediaRouter.CALLBACK_FLAG_REQUEST_DISCOVERY)
+                currentRoute = mediaRouter?.selectedRoute
+                Log.v(TAG, "MediaRouter initialized. Current route: ${currentRoute?.name}")
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to initialize MediaRouter", e)
+            }
+        }
 
         Log.v(TAG, "listener created")
         if (Preference(applicationContext).isDebugLogEnabled()) {
@@ -181,6 +229,15 @@ class NotificationListener : NotificationListenerService() {
 
     override fun onDestroy() {
         super.onDestroy()
+        // Cleanup MediaRouter
+        handler.post {
+            try {
+                mediaRouter?.removeCallback(mediaRouterCallback)
+            } catch (e: Exception) {
+                Log.e(TAG, "Error removing MediaRouter callback", e)
+            }
+        }
+        
         Log.v(TAG, "listener destroyed")
         if (Preference(applicationContext).isDebugLogEnabled()) {
             LogManager.addLifecycleLog(
@@ -239,17 +296,38 @@ class NotificationListener : NotificationListenerService() {
                                     }
 
                                     val isMusicStreamMuted = this.isMusicMuted(audioManager!!)
+                                    
+                                    // Check for casting
+                                    val route = currentRoute
+                                    // DEBUG: Force isCasting to true to test logic flow
+                                    val isCasting = true // route != null && route.playbackType == MediaRouter.RouteInfo.PLAYBACK_TYPE_REMOTE
+                                    
                                     if (!isMuted || !isMusicStreamMuted) {
                                         Log.v(TAG, "'MusicStream' muted? -> $isMusicStreamMuted")
                                         Log.v(TAG, "Ad detected muting, state-> $isMuted to ${!isMuted}, currentPackage: $currentPackage")
-                                        this.mute(audioManager, appNotificationHelper, preference)
+                                        
+                                        // DEBUG: Simplified check for null route to prevent crash during mock
+                                        if (isCasting && (route == null || route.volumeHandling == MediaRouter.RouteInfo.PLAYBACK_VOLUME_VARIABLE)) {
+                                            Log.v(TAG, "Casting detected on route: ${route?.name ?: "MOCK_ROUTE"}. Muting remote volume.")
+                                            handler.post {
+                                                if (route != null) {
+                                                    originalRemoteVolume = route.volume
+                                                    route.requestSetVolume(0)
+                                                } else {
+                                                    Log.v(TAG, "MOCK: Would set remote volume to 0")
+                                                }
+                                            }
+                                        } else {
+                                            this.mute(audioManager, appNotificationHelper, preference)
+                                        }
+                                        
                                         if (isDebugEnabled) {
                                             LogManager.addLifecycleLog(LogEntry(
                                                 appName = "AdSilence",
                                                 timestamp = System.currentTimeMillis(),
                                                 isAd = true,
                                                 title = "Muted",
-                                                text = "Muted audio for $currentPackage ($packageName)",
+                                                text = if (isCasting) "Muted remote cast on ${route?.name}" else "Muted audio for $currentPackage ($packageName)",
                                                 subText = "Action"
                                             ))
                                         }
@@ -268,27 +346,60 @@ class NotificationListener : NotificationListenerService() {
                                         // https://github.com/aghontpi/ad-silence/pull/282#issue-3682929324
                                         if (unmuteRunnable == null) {
                                             unmuteRunnable = Runnable {
+                                                val route = this@NotificationListener.currentRoute
                                                 if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
                                                     Log.v(TAG, "Not an ad, Unmuting, < M")
                                                     // for android 5 & 5.1, unmute has to be done, count x mutedCount
+                                                    // DEBUG: Force isCasting to true
+                                                    val isCasting = true // route != null && route.playbackType == MediaRouter.RouteInfo.PLAYBACK_TYPE_REMOTE
+                                                    
                                                     while (muteCount > 0) {
+                                                        // DEBUG: Handle null route safely
+                                                        if (isCasting && (route == null || (route.volumeHandling == MediaRouter.RouteInfo.PLAYBACK_VOLUME_VARIABLE && originalRemoteVolume != -1))) {
+                                                             Log.v(TAG, "Restoring remote volume to $originalRemoteVolume")
+                                                             handler.post {
+                                                                 if (route != null) {
+                                                                     route.requestSetVolume(originalRemoteVolume)
+                                                                 } else {
+                                                                     Log.v(TAG, "MOCK: Would restore remote volume")
+                                                                 }
+                                                                 originalRemoteVolume = -1
+                                                             }
+                                                        } else {
+                                                            this@run.unmute(
+                                                                audioManager,
+                                                                appNotificationHelper,
+                                                                currentPackage,
+                                                                preference
+                                                            )
+                                                        }
+                                                        muteCount--
+                                                    }
+                                                    isMuted = false
+                                                } else {
+                                                    Log.v(TAG, "Not an ad, Unmuting, > M")
+                                                    // DEBUG: Force isCasting to true
+                                                    val isCasting = true // route != null && route.playbackType == MediaRouter.RouteInfo.PLAYBACK_TYPE_REMOTE
+                                                    
+                                                    // DEBUG: Handle null route safely
+                                                    if (isCasting && (route == null || (route.volumeHandling == MediaRouter.RouteInfo.PLAYBACK_VOLUME_VARIABLE && originalRemoteVolume != -1))) {
+                                                         Log.v(TAG, "Restoring remote volume to $originalRemoteVolume")
+                                                         handler.post {
+                                                             if (route != null) {
+                                                                 route.requestSetVolume(originalRemoteVolume)
+                                                             } else {
+                                                                 Log.v(TAG, "MOCK: Would restore remote volume")
+                                                             }
+                                                             originalRemoteVolume = -1
+                                                         }
+                                                    } else {
                                                         this@run.unmute(
                                                             audioManager,
                                                             appNotificationHelper,
                                                             currentPackage,
                                                             preference
                                                         )
-                                                        muteCount--
                                                     }
-                                                    isMuted = false
-                                                } else {
-                                                    Log.v(TAG, "Not an ad, Unmuting, > M")
-                                                    this@run.unmute(
-                                                        audioManager,
-                                                        appNotificationHelper,
-                                                        currentPackage,
-                                                        preference
-                                                    )
                                                     isMuted = false
                                                 }
                                                 if (isDebugEnabled) {

--- a/app/src/main/java/bluepie/ad_silence/NotificationListener.kt
+++ b/app/src/main/java/bluepie/ad_silence/NotificationListener.kt
@@ -10,9 +10,7 @@ import android.service.notification.StatusBarNotification
 import android.util.Log
 import android.os.Handler
 import android.os.Looper
-import androidx.mediarouter.media.MediaRouter
-import androidx.mediarouter.media.MediaRouteSelector
-import androidx.mediarouter.media.MediaControlIntent
+import android.media.MediaRouter
 
 @SuppressLint("LongLogTag")
 class NotificationListener : NotificationListenerService() {
@@ -29,18 +27,17 @@ class NotificationListener : NotificationListenerService() {
     private var mediaRouter: MediaRouter? = null
     private var currentRoute: MediaRouter.RouteInfo? = null
     private var originalRemoteVolume: Int = -1
-    private val mediaRouterCallback = object : MediaRouter.Callback() {
-        override fun onRouteSelected(router: MediaRouter, route: MediaRouter.RouteInfo) {
+    private val mediaRouterCallback = object : MediaRouter.SimpleCallback() {
+        override fun onRouteSelected(router: MediaRouter, type: Int, route: MediaRouter.RouteInfo) {
             currentRoute = route
             Log.v(TAG, "MediaRouter: Route selected: ${route.name}, type: ${route.playbackType}")
             // If route changes while muted, reset the original volume tracking
             if (originalRemoteVolume != -1) {
                 originalRemoteVolume = -1
-                // potentially we could try to unmute the old route if we had a reference, but simplified for now
             }
         }
 
-        override fun onRouteUnselected(router: MediaRouter, route: MediaRouter.RouteInfo) {
+        override fun onRouteUnselected(router: MediaRouter, type: Int, route: MediaRouter.RouteInfo) {
             Log.v(TAG, "MediaRouter: Route unselected: ${route.name}")
             if (currentRoute == route) {
                 currentRoute = null
@@ -65,13 +62,9 @@ class NotificationListener : NotificationListenerService() {
         // Initialize MediaRouter on main thread
         handler.post {
             try {
-                mediaRouter = MediaRouter.getInstance(applicationContext)
-                val selector = MediaRouteSelector.Builder()
-                    .addControlCategory(MediaControlIntent.CATEGORY_REMOTE_PLAYBACK)
-                    .addControlCategory(MediaControlIntent.CATEGORY_LIVE_AUDIO)
-                    .build()
-                mediaRouter?.addCallback(selector, mediaRouterCallback, MediaRouter.CALLBACK_FLAG_REQUEST_DISCOVERY)
-                currentRoute = mediaRouter?.selectedRoute
+                mediaRouter = applicationContext.getSystemService(android.content.Context.MEDIA_ROUTER_SERVICE) as MediaRouter
+                mediaRouter?.addCallback(MediaRouter.ROUTE_TYPE_LIVE_AUDIO, mediaRouterCallback, MediaRouter.CALLBACK_FLAG_PERFORM_ACTIVE_SCAN)
+                currentRoute = mediaRouter?.getSelectedRoute(MediaRouter.ROUTE_TYPE_LIVE_AUDIO)
                 Log.v(TAG, "MediaRouter initialized. Current route: ${currentRoute?.name}")
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to initialize MediaRouter", e)
@@ -310,17 +303,33 @@ class NotificationListener : NotificationListenerService() {
                                     
                                     // Check for casting
                                     val route = currentRoute
-                                    val isCasting = route != null && route.playbackType == MediaRouter.RouteInfo.PLAYBACK_TYPE_REMOTE
+                                    var isCasting = route != null && route.playbackType == MediaRouter.RouteInfo.PLAYBACK_TYPE_REMOTE
+                                    var castController: android.media.session.MediaController? = null
+
+                                    // Fallback: If MediaRouter says local, check notifications for a casting token
+                                    if (!isCasting) {
+                                        castController = getMediaControllerForCasting()
+                                        if (castController != null) {
+                                            isCasting = true
+                                            Log.v(TAG, "Casting detected via Notification Fallback")
+                                        }
+                                    }
                                     
                                     if (!isMuted || !isMusicStreamMuted) {
                                         Log.v(TAG, "'MusicStream' muted? -> $isMusicStreamMuted")
                                         Log.v(TAG, "Ad detected muting, state-> $isMuted to ${!isMuted}, currentPackage: $currentPackage")
                                         
-                                        if (isCasting && (route != null && route.volumeHandling == MediaRouter.RouteInfo.PLAYBACK_VOLUME_VARIABLE)) {
-                                            Log.v(TAG, "Casting detected on route: ${route.name}. Muting remote volume.")
-                                            handler.post {
-                                                originalRemoteVolume = route.volume
-                                                route.requestSetVolume(0)
+                                        if (isCasting) {
+                                            if (route != null && route.playbackType == MediaRouter.RouteInfo.PLAYBACK_TYPE_REMOTE) {
+                                                Log.v(TAG, "Casting detected on route: ${route.name}. Muting remote volume.")
+                                                handler.post {
+                                                    originalRemoteVolume = route.volume
+                                                    route.requestSetVolume(0)
+                                                }
+                                            } else {
+                                                if (castMuteManager.tryMute(this@NotificationListener)) {
+                                                    Log.v(TAG, "Muted via CastMuteManager (Notification Fallback)")
+                                                }
                                             }
                                         } else {
                                             if (castMuteManager.tryMute(this@NotificationListener)) {
@@ -359,15 +368,25 @@ class NotificationListener : NotificationListenerService() {
                                                 if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
                                                     Log.v(TAG, "Not an ad, Unmuting, < M")
                                                     // for android 5 & 5.1, unmute has to be done, count x mutedCount
-                                                    val isCasting = route != null && route.playbackType == MediaRouter.RouteInfo.PLAYBACK_TYPE_REMOTE
-
+                                                    // Check for casting (Route or Fallback)
+                                                    val currentRoute = this@NotificationListener.currentRoute
+                                                    val isRemoteRoute = currentRoute != null && currentRoute.playbackType == MediaRouter.RouteInfo.PLAYBACK_TYPE_REMOTE
+                                                    val fallbackController = if (!isRemoteRoute) getMediaControllerForCasting() else null
+                                                    val isCasting = isRemoteRoute || fallbackController != null
+                                                    
                                                     while (muteCount > 0) {
-                                                        if (isCasting && (route != null && route.volumeHandling == MediaRouter.RouteInfo.PLAYBACK_VOLUME_VARIABLE && originalRemoteVolume != -1)) {
-                                                             Log.v(TAG, "Restoring remote volume to $originalRemoteVolume")
-                                                             handler.post {
-                                                                 route.requestSetVolume(originalRemoteVolume)
-                                                                 originalRemoteVolume = -1
-                                                             }
+                                                        if (isCasting) {
+                                                            if (isRemoteRoute && currentRoute?.volumeHandling == MediaRouter.RouteInfo.PLAYBACK_VOLUME_VARIABLE && originalRemoteVolume != -1) {
+                                                                 Log.v(TAG, "Restoring remote volume to $originalRemoteVolume")
+                                                                 handler.post {
+                                                                     currentRoute.requestSetVolume(originalRemoteVolume)
+                                                                     originalRemoteVolume = -1
+                                                                 }
+                                                            } else {
+                                                                if (castMuteManager.tryUnmute(this@NotificationListener)) {
+                                                                    Log.v(TAG, "Unmuted via CastMuteManager (< M)")
+                                                                }
+                                                            }
                                                         } else {
                                                             if (castMuteManager.tryUnmute(this@NotificationListener)) {
                                                                 Log.v(TAG, "Unmuted via CastMuteManager (< M)")
@@ -385,13 +404,24 @@ class NotificationListener : NotificationListenerService() {
                                                     isMuted = false
                                                 } else {
                                                     Log.v(TAG, "Not an ad, Unmuting, > M")
-                                                    val isCasting = route != null && route.playbackType == MediaRouter.RouteInfo.PLAYBACK_TYPE_REMOTE
+                                                     // Check for casting (Route or Fallback) 
+                                                    
+                                                    val currentRoute = this@NotificationListener.currentRoute
+                                                    val isRemoteRoute = currentRoute != null && currentRoute.playbackType == MediaRouter.RouteInfo.PLAYBACK_TYPE_REMOTE
+                                                    val fallbackController = if (!isRemoteRoute) getMediaControllerForCasting() else null
+                                                    val isCasting = isRemoteRoute || fallbackController != null
 
-                                                    if (isCasting && (route != null && route.volumeHandling == MediaRouter.RouteInfo.PLAYBACK_VOLUME_VARIABLE && originalRemoteVolume != -1)) {
-                                                         Log.v(TAG, "Restoring remote volume to $originalRemoteVolume")
-                                                         handler.post {
-                                                             route.requestSetVolume(originalRemoteVolume)
-                                                             originalRemoteVolume = -1
+                                                    if (isCasting) {
+                                                         if (isRemoteRoute && currentRoute?.volumeHandling == MediaRouter.RouteInfo.PLAYBACK_VOLUME_VARIABLE && originalRemoteVolume != -1) {
+                                                             Log.v(TAG, "Restoring remote volume to $originalRemoteVolume")
+                                                             handler.post {
+                                                                 currentRoute.requestSetVolume(originalRemoteVolume)
+                                                                 originalRemoteVolume = -1
+                                                             }
+                                                         } else {
+                                                             if (castMuteManager.tryUnmute(this@NotificationListener)) {
+                                                                 Log.v(TAG, "Unmuted via CastMuteManager")
+                                                             }
                                                          }
                                                     } else {
                                                         if (castMuteManager.tryUnmute(this@NotificationListener)) {

--- a/app/src/main/java/bluepie/ad_silence/Utils.kt
+++ b/app/src/main/java/bluepie/ad_silence/Utils.kt
@@ -65,6 +65,16 @@ class Utils {
                     TAG,
                     "Could not retrieve stream volume for stream type " + AudioManager.STREAM_MUSIC
                 )
+                  if (Preference(context).isDebugLogEnabled()) {
+                    LogManager.addLog(LogEntry(
+                        appName = "AdSilence",
+                        timestamp = System.currentTimeMillis(),
+                        isAd = false,
+                        title = "Volume Check Error",
+                        text = "Could not retrieve stream volume (Runtime Exception)",
+                        subText = "Error"
+                    ))
+                }
                 audoManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC)
             }
             return volume == 0
@@ -76,6 +86,17 @@ class Utils {
              audioManager?.adjustVolume(AudioManager.ADJUST_MUTE, 0)
         } else {
              audioManager?.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_MUTE, 0)
+        }
+
+        if (preference.isDebugLogEnabled()) {
+            LogManager.addLifecycleLog(LogEntry(
+                appName = "AdSilence",
+                timestamp = System.currentTimeMillis(),
+                isAd = true,
+                title = "System Mute Executed",
+                text = "Mute command sent to AudioManager",
+                subText = "Action"
+            ))
         }
 
         this.updateNotification("AdSilence, ad-detected", preference, addNotificationHelper)
@@ -102,6 +123,17 @@ class Utils {
              audioManager?.adjustVolume(AudioManager.ADJUST_UNMUTE, 0)
         } else {
              audioManager?.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_UNMUTE, 0)
+        }
+
+        if (preference.isDebugLogEnabled()) {
+            LogManager.addLifecycleLog(LogEntry(
+                appName = "AdSilence",
+                timestamp = System.currentTimeMillis(),
+                isAd = false,
+                title = "System Unmute Executed",
+                text = "Unmute command sent to AudioManager",
+                subText = "Action"
+            ))
         }
 
         this.updateNotification("AdSilence, listening for ads", preference, addNotificationHelper)

--- a/app/src/main/res/layout/dialog_debug_log.xml
+++ b/app/src/main/res/layout/dialog_debug_log.xml
@@ -23,12 +23,6 @@
             android:textSize="20sp"
             android:textStyle="bold" />
 
-        <Switch
-            android:id="@+id/debug_log_toggle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="8dp" />
-
         <Button
             android:id="@+id/test_mute_btn"
             android:layout_width="wrap_content"
@@ -44,11 +38,17 @@
             android:id="@+id/clear_log_btn"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
             android:background="@drawable/bg_button_rounded"
             android:minHeight="32dp"
             android:text="@string/clear"
             android:textColor="?android:attr/textColorPrimary"
             android:textSize="12sp" />
+
+        <Switch
+            android:id="@+id/debug_log_toggle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/dialog_debug_log.xml
+++ b/app/src/main/res/layout/dialog_debug_log.xml
@@ -30,13 +30,13 @@
             android:layout_marginEnd="8dp" />
 
         <Button
-            android:id="@+id/mock_log_btn"
+            android:id="@+id/test_mute_btn"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginEnd="8dp"
             android:background="@drawable/bg_button_rounded"
             android:minHeight="32dp"
-            android:text="@string/mock"
+            android:text="Mute/Unmute"
             android:textColor="?android:attr/textColorPrimary"
             android:textSize="12sp" />
 
@@ -59,9 +59,20 @@
         android:gravity="center"
         android:textSize="12sp"
         android:textColor="?android:attr/textColorSecondary"
-        android:layout_marginBottom="16dp"
+        android:layout_marginBottom="8dp"
         android:visibility="gone"
         tools:text="Active for: 2h 30m" />
+
+    <TextView
+        android:id="@+id/dialog_casting_status_text_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:textSize="12sp"
+        android:textColor="?android:attr/textColorSecondary"
+        android:layout_marginBottom="16dp"
+        android:visibility="gone"
+        tools:text="Casting: Living Room TV" />
 
     <ListView
         android:id="@+id/log_list_view"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -98,7 +98,6 @@
     <string name="enable_ad_silence">Enable Ad-Silence</string>
     <string name="debug_log">Debug Log</string>
 
-    <string name="mock">Mock</string>
     <string name="clear">Clear</string>
     <string name="channel_name">Service Status</string>
     <string name="channel_description">Persistent notification showing that AdSilence is active</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,6 +97,8 @@
     <string name="ad_muting_status">Ad-Muting Status</string>
     <string name="enable_ad_silence">Enable Ad-Silence</string>
     <string name="debug_log">Debug Log</string>
+    <string name="custom_detection">Custom Detection</string>
+    <string name="mock">Mock</string>
 
     <string name="clear">Clear</string>
     <string name="channel_name">Service Status</string>


### PR DESCRIPTION
This **PR** adds casting support to the app, additionally uses `androidx.mediarouter:mediarouter` hence will increase the app size, but since its a majorly requested feature... the pro's outweigh the app size. 

- This additonally adds a test "MUTE" / "UNMUTE" button that correctly mutes the casted device or this device directly.
- In the debug view, we have a status text for reporting the current status of casting.
- added debug log based on the current status of the system.

<img width="380" height="auto" alt="Screenshot_20251221-153049" src="https://github.com/user-attachments/assets/121d6a2c-bef3-4f88-842e-bed9a052fcf6" />



Tested on a pixel device using Spotify while casting to android tv.


edit: 

using the androidx.mediarouter.. library, inceases final buid size to 750+ KB, will have to use https://developer.android.com/reference/android/media/MediaRouter native library since Im only targetting android 5 and above. if removing language files from lib the size gets reduced to 650+, still I dont use any of the functions from the library, so have to remove it and change the implementation.

<img width="829" height="419" alt="Screenshot 2025-12-21 at 5 00 56 PM" src="https://github.com/user-attachments/assets/e53b52f9-cb18-49fd-8cbd-3422aa958f1b" />

update/ edit 2: 

removed using androidx library as its increasing app size, I want it to be minimal, we dont use the functions from androidx library.. just use 3 imports from the whole library.. instead of that used native functions.. dont need backward compatibility also as I am targeting android v5 and above for app, its changed here https://github.com/aghontpi/ad-silence/pull/308/commits/1cdb9e1a3ec08e8d1105a3771ecea46f19cf351f and the prod build size now is back to 148kb.. ~150kb.