### PR TITLE
Feat: Refine preloaded app configuration

### DIFF
--- a/app/src/main/java/bluepie/ad_silence/AdSilenceActivity.kt
+++ b/app/src/main/java/bluepie/ad_silence/AdSilenceActivity.kt
@@ -17,6 +17,7 @@ import android.text.Html.fromHtml
 import android.text.method.LinkMovementMethod
 import android.util.Log
 import android.view.View
+import android.view.MotionEvent
 import android.widget.*
 import androidx.annotation.RequiresApi
 import androidx.core.app.ActivityCompat
@@ -363,14 +364,18 @@ class AdSilenceActivity : Activity() {
             val appSelectionView = layoutInflater.inflate(R.layout.app_selection, null)
             val preference = Preference(applicationContext)
 
+            val updateResetButtonVisibility = { pkgName: String, resetBtn: View ->
+                if (preference.isCustomAppConfigured(SupportedApps.CUSTOM, pkgName)) {
+                    resetBtn.visibility = View.VISIBLE
+                } else {
+                    resetBtn.visibility = View.GONE
+                }
+            }
+
             appSelectionView.findViewById<Switch>(R.id.accuradio_selection_switch)?.run {
                 this.isEnabled = isAccuradioInstalled
                 this.isChecked = preference.isAppConfigured(SupportedApps.ACCURADIO)
-                "${getString(R.string.accuradio)} ${
-                    if (isAccuradioInstalled) "" else context.getString(
-                        R.string.not_installed
-                    )
-                }".also { this.text = it }
+                this.text = "" 
                 this.setOnClickListener {
                     preference.setAppConfigured(
                         SupportedApps.ACCURADIO,
@@ -378,17 +383,27 @@ class AdSilenceActivity : Activity() {
                     )
                 }
             }
+            appSelectionView.findViewById<TextView>(R.id.tv_accuradio)?.text = 
+                "${getString(R.string.accuradio)} ${if (isAccuradioInstalled) "" else getString(R.string.not_installed)}"
+            val accuradioResetBtn = appSelectionView.findViewById<ImageView>(R.id.accuradio_reset_btn)
+            updateResetButtonVisibility(getString(R.string.accuradio_pkg_name), accuradioResetBtn)
+            accuradioResetBtn.setOnClickListener {
+                showResetConfirmationDialog(getString(R.string.accuradio)) {
+                    preference.removeCustomApp(getString(R.string.accuradio_pkg_name))
+                    updateResetButtonVisibility(getString(R.string.accuradio_pkg_name), accuradioResetBtn)
+                    Toast.makeText(this, "Reset to default", Toast.LENGTH_SHORT).show()
+                }
+            }
+            appSelectionView.findViewById<ImageView>(R.id.accuradio_edit_btn)?.setOnClickListener {
+                handlePreloadedAppEdit(SupportedApps.ACCURADIO, appSelectionView.findViewById(R.id.custom_apps_container), preference) {
+                    updateResetButtonVisibility(getString(R.string.accuradio_pkg_name), accuradioResetBtn)
+                }
+            }
 
             appSelectionView.findViewById<Switch>(R.id.spotify_selection_switch)?.run {
                 this.isEnabled = isSpotifyInstalled
                 this.isChecked = preference.isAppConfigured(SupportedApps.SPOTIFY)
-                "${getString(R.string.spotify)} ${
-                    if (isSpotifyInstalled) "" else context.getString(
-                        R.string.not_installed
-                    )
-                }".also {
-                    this.text = it
-                }
+                this.text = ""
                 this.setOnClickListener {
                     preference.setAppConfigured(
                         SupportedApps.SPOTIFY,
@@ -396,17 +411,27 @@ class AdSilenceActivity : Activity() {
                     )
                 }
             }
+            appSelectionView.findViewById<TextView>(R.id.tv_spotify)?.text = 
+                "${getString(R.string.spotify)} ${if (isSpotifyInstalled) "" else getString(R.string.not_installed)}"
+            val spotifyResetBtn = appSelectionView.findViewById<ImageView>(R.id.spotify_reset_btn)
+            updateResetButtonVisibility(getString(R.string.spotify_package_name), spotifyResetBtn)
+            spotifyResetBtn.setOnClickListener {
+                showResetConfirmationDialog(getString(R.string.spotify)) {
+                    preference.removeCustomApp(getString(R.string.spotify_package_name))
+                    updateResetButtonVisibility(getString(R.string.spotify_package_name), spotifyResetBtn)
+                    Toast.makeText(this, "Reset to default", Toast.LENGTH_SHORT).show()
+                }
+            }
+            appSelectionView.findViewById<ImageView>(R.id.spotify_edit_btn)?.setOnClickListener {
+                handlePreloadedAppEdit(SupportedApps.SPOTIFY, appSelectionView.findViewById(R.id.custom_apps_container), preference) {
+                    updateResetButtonVisibility(getString(R.string.spotify_package_name), spotifyResetBtn)
+                }
+            }
 
             appSelectionView.findViewById<Switch>(R.id.tidal_selection_switch)?.run {
                 this.isEnabled = isTidalInstalled
                 this.isChecked = preference.isAppConfigured(SupportedApps.TIDAL)
-                "${context.getString(R.string.tidal)} ${
-                    if (isTidalInstalled) "" else context.getString(
-                        R.string.not_installed
-                    )
-                }".also {
-                    this.text = it
-                }
+                this.text = ""
                 this.setOnClickListener {
                     preference.setAppConfigured(
                         SupportedApps.TIDAL,
@@ -414,17 +439,27 @@ class AdSilenceActivity : Activity() {
                     )
                 }
             }
+            appSelectionView.findViewById<TextView>(R.id.tv_tidal)?.text = 
+                "${getString(R.string.tidal)} ${if (isTidalInstalled) "" else getString(R.string.not_installed)}"
+            val tidalResetBtn = appSelectionView.findViewById<ImageView>(R.id.tidal_reset_btn)
+            updateResetButtonVisibility(getString(R.string.tidal_package_name), tidalResetBtn)
+            tidalResetBtn.setOnClickListener {
+                 showResetConfirmationDialog(getString(R.string.tidal)) {
+                    preference.removeCustomApp(getString(R.string.tidal_package_name))
+                    updateResetButtonVisibility(getString(R.string.tidal_package_name), tidalResetBtn)
+                    Toast.makeText(this, "Reset to default", Toast.LENGTH_SHORT).show()
+                 }
+            }
+            appSelectionView.findViewById<ImageView>(R.id.tidal_edit_btn)?.setOnClickListener {
+                handlePreloadedAppEdit(SupportedApps.TIDAL, appSelectionView.findViewById(R.id.custom_apps_container), preference) {
+                    updateResetButtonVisibility(getString(R.string.tidal_package_name), tidalResetBtn)
+                }
+            }
 
             appSelectionView.findViewById<Switch>(R.id.spotify_lite_selection_switch)?.run {
                 this.isEnabled = isSpotifyLiteInstalled
                 this.isChecked = preference.isAppConfigured(SupportedApps.SPOTIFY_LITE)
-                "${context.getString(R.string.spotify_lite)} ${
-                    if (isSpotifyLiteInstalled) "" else context.getString(
-                        R.string.not_installed
-                    )
-                }".also {
-                    this.text = it
-                }
+                this.text = ""
                 this.setOnClickListener {
                     preference.setAppConfigured(
                         SupportedApps.SPOTIFY_LITE,
@@ -432,17 +467,27 @@ class AdSilenceActivity : Activity() {
                     )
                 }
             }
+            appSelectionView.findViewById<TextView>(R.id.tv_spotify_lite)?.text = 
+                "${getString(R.string.spotify_lite)} ${if (isSpotifyLiteInstalled) "" else getString(R.string.not_installed)}"
+            val spotifyLiteResetBtn = appSelectionView.findViewById<ImageView>(R.id.spotify_lite_reset_btn)
+            updateResetButtonVisibility(getString(R.string.spotify_lite_package_name), spotifyLiteResetBtn)
+            spotifyLiteResetBtn.setOnClickListener {
+                showResetConfirmationDialog(getString(R.string.spotify_lite)) {
+                    preference.removeCustomApp(getString(R.string.spotify_lite_package_name))
+                    updateResetButtonVisibility(getString(R.string.spotify_lite_package_name), spotifyLiteResetBtn)
+                    Toast.makeText(this, "Reset to default", Toast.LENGTH_SHORT).show()
+                }
+            }
+            appSelectionView.findViewById<ImageView>(R.id.spotify_lite_edit_btn)?.setOnClickListener {
+                handlePreloadedAppEdit(SupportedApps.SPOTIFY_LITE, appSelectionView.findViewById(R.id.custom_apps_container), preference) {
+                    updateResetButtonVisibility(getString(R.string.spotify_lite_package_name), spotifyLiteResetBtn)
+                }
+            }
 
             appSelectionView.findViewById<Switch>(R.id.pandora_selection_switch)?.run {
                 this.isEnabled = isPandoraInstalled
                 this.isChecked = preference.isAppConfigured(SupportedApps.PANDORA)
-                "${context.getString(R.string.pandora)} ${
-                    if (isPandoraInstalled) applicationContext.getString(R.string.beta) else context.getString(
-                        R.string.not_installed
-                    )
-                }".also {
-                    this.text = it
-                }
+                this.text = ""
                 this.setOnClickListener {
                     preference.setAppConfigured(
                         SupportedApps.PANDORA,
@@ -450,17 +495,27 @@ class AdSilenceActivity : Activity() {
                     )
                 }
             }
+            appSelectionView.findViewById<TextView>(R.id.tv_pandora)?.text = 
+                "${getString(R.string.pandora)} ${if (isPandoraInstalled) getString(R.string.beta) else getString(R.string.not_installed)}"
+            val pandoraResetBtn = appSelectionView.findViewById<ImageView>(R.id.pandora_reset_btn)
+            updateResetButtonVisibility(getString(R.string.pandora_package_name), pandoraResetBtn)
+            pandoraResetBtn.setOnClickListener {
+                showResetConfirmationDialog(getString(R.string.pandora)) {
+                    preference.removeCustomApp(getString(R.string.pandora_package_name))
+                    updateResetButtonVisibility(getString(R.string.pandora_package_name), pandoraResetBtn)
+                    Toast.makeText(this, "Reset to default", Toast.LENGTH_SHORT).show()
+                }
+            }
+            appSelectionView.findViewById<ImageView>(R.id.pandora_edit_btn)?.setOnClickListener {
+                handlePreloadedAppEdit(SupportedApps.PANDORA, appSelectionView.findViewById(R.id.custom_apps_container), preference) {
+                    updateResetButtonVisibility(getString(R.string.pandora_package_name), pandoraResetBtn)
+                }
+            }
 
             appSelectionView.findViewById<Switch>(R.id.liveone_selection_switch)?.run {
                 this.isEnabled = isLiveOneInstalled
                 this.isChecked = preference.isAppConfigured(SupportedApps.LiveOne)
-                "${context.getString(R.string.liveone)} ${
-                    if (isLiveOneInstalled) applicationContext.getString(R.string.beta) else context.getString(
-                        R.string.not_installed
-                    )
-                }".also {
-                    this.text = it
-                }
+                this.text = ""
                 this.setOnClickListener {
                     preference.setAppConfigured(
                         SupportedApps.LiveOne,
@@ -468,20 +523,48 @@ class AdSilenceActivity : Activity() {
                     )
                 }
             }
+            appSelectionView.findViewById<TextView>(R.id.tv_liveone)?.text = 
+                "${getString(R.string.liveone)} ${if (isLiveOneInstalled) getString(R.string.beta) else getString(R.string.not_installed)}"
+            val liveOneResetBtn = appSelectionView.findViewById<ImageView>(R.id.liveone_reset_btn)
+            updateResetButtonVisibility(getString(R.string.liveOne_package_name), liveOneResetBtn)
+            liveOneResetBtn.setOnClickListener {
+                showResetConfirmationDialog(getString(R.string.liveone)) {
+                    preference.removeCustomApp(getString(R.string.liveOne_package_name))
+                    updateResetButtonVisibility(getString(R.string.liveOne_package_name), liveOneResetBtn)
+                    Toast.makeText(this, "Reset to default", Toast.LENGTH_SHORT).show()
+                }
+            }
+            appSelectionView.findViewById<ImageView>(R.id.liveone_edit_btn)?.setOnClickListener {
+                handlePreloadedAppEdit(SupportedApps.LiveOne, appSelectionView.findViewById(R.id.custom_apps_container), preference) {
+                    updateResetButtonVisibility(getString(R.string.liveOne_package_name), liveOneResetBtn)
+                }
+            }
 
             appSelectionView.findViewById<Switch>(R.id.soundcloud_selection_switch)?.run {
                 this.isEnabled = isSoundcloudInstalled
                 this.isChecked = preference.isAppConfigured(SupportedApps.Soundcloud)
-                "${context.getString(R.string.soundcloud)} ${
-                    if (isSoundcloudInstalled) "" else context.getString(R.string.not_installed)
-                }".also {
-                    this.text = it
-                }
+                this.text = ""
                 this.setOnClickListener {
                     preference.setAppConfigured(
                         SupportedApps.Soundcloud,
                         !preference.isAppConfigured(SupportedApps.Soundcloud)
                     )
+                }
+            }
+            appSelectionView.findViewById<TextView>(R.id.tv_soundcloud)?.text = 
+                "${getString(R.string.soundcloud)} ${if (isSoundcloudInstalled) "" else getString(R.string.not_installed)}"
+            val soundcloudResetBtn = appSelectionView.findViewById<ImageView>(R.id.soundcloud_reset_btn)
+            updateResetButtonVisibility(getString(R.string.soundcloud_package_name), soundcloudResetBtn)
+            soundcloudResetBtn.setOnClickListener {
+                 showResetConfirmationDialog(getString(R.string.soundcloud)) {
+                    preference.removeCustomApp(getString(R.string.soundcloud_package_name))
+                    updateResetButtonVisibility(getString(R.string.soundcloud_package_name), soundcloudResetBtn)
+                    Toast.makeText(this, "Reset to default", Toast.LENGTH_SHORT).show()
+                 }
+            }
+            appSelectionView.findViewById<ImageView>(R.id.soundcloud_edit_btn)?.setOnClickListener {
+                handlePreloadedAppEdit(SupportedApps.Soundcloud, appSelectionView.findViewById(R.id.custom_apps_container), preference) {
+                    updateResetButtonVisibility(getString(R.string.soundcloud_package_name), soundcloudResetBtn)
                 }
             }
 
@@ -713,7 +796,17 @@ class AdSilenceActivity : Activity() {
         val customApps = preference.getCustomApps()
         Log.v(TAG, "Found ${customApps.size} custom apps")
         
-        customApps.forEach { customApp ->
+        val preloadedPackageNames = listOf(
+            getString(R.string.accuradio_pkg_name),
+            getString(R.string.spotify_package_name),
+            getString(R.string.spotify_lite_package_name),
+            getString(R.string.tidal_package_name),
+            getString(R.string.pandora_package_name),
+            getString(R.string.liveOne_package_name),
+            getString(R.string.soundcloud_package_name)
+        )
+
+        customApps.filter { !preloadedPackageNames.contains(it.packageName) }.forEach { customApp ->
             val row = LinearLayout(this)
             row.orientation = LinearLayout.HORIZONTAL
             row.gravity = android.view.Gravity.CENTER_VERTICAL
@@ -809,7 +902,79 @@ class AdSilenceActivity : Activity() {
         }
     }
 
-    private fun showAddCustomAppDialog(appToEdit: CustomApp? = null, onSuccess: () -> Unit = {}) {
+    private fun handlePreloadedAppEdit(
+        app: SupportedApps, 
+        container: LinearLayout, 
+        preference: Preference, 
+        onSuccess: () -> Unit = {}
+    ) {
+        val pkgNameId = when (app) {
+            SupportedApps.ACCURADIO -> R.string.accuradio_pkg_name
+            SupportedApps.SPOTIFY -> R.string.spotify_package_name
+            SupportedApps.SPOTIFY_LITE -> R.string.spotify_lite_package_name
+            SupportedApps.TIDAL -> R.string.tidal_package_name
+            SupportedApps.PANDORA -> R.string.pandora_package_name
+            SupportedApps.LiveOne -> R.string.liveOne_package_name
+            SupportedApps.Soundcloud -> R.string.soundcloud_package_name
+            else -> return
+        }
+        val pkgName = getString(pkgNameId)
+        val appNameId = when(app) {
+            SupportedApps.ACCURADIO -> R.string.accuradio
+            SupportedApps.SPOTIFY -> R.string.spotify
+            SupportedApps.SPOTIFY_LITE -> R.string.spotify_lite
+            SupportedApps.TIDAL -> R.string.tidal
+            SupportedApps.PANDORA -> R.string.pandora
+            SupportedApps.LiveOne -> R.string.liveone
+            SupportedApps.Soundcloud -> R.string.soundcloud
+             else -> return
+        }
+        val appName = getString(appNameId)
+
+        val customApps = preference.getCustomApps()
+        val existingApp = customApps.find { it.packageName == pkgName }
+        
+        val appToEdit = existingApp ?: CustomApp(
+            name = appName,
+            packageName = pkgName,
+            keywords = DefaultAppConfig.getDefaultKeywords(app, applicationContext),
+            isEnabled = true, 
+            unmuteDelay = Utils().getUnmuteDelay(app, pkgName, preference)
+        )
+        
+        showAddCustomAppDialog(appToEdit, isPreloaded = true) {
+            populateCustomApps(container, preference)
+            onSuccess()
+        }
+    }
+
+    private fun showResetConfirmationDialog(appName: String, onConfirm: () -> Unit) {
+        val dialogView = layoutInflater.inflate(R.layout.dialog_delete_custom_app, null)
+        val dialog = AlertDialog.Builder(this)
+            .setView(dialogView)
+            .create()
+
+        dialogView.findViewById<TextView>(R.id.tv_dialog_title).text = getString(R.string.reset_app_configuration)
+
+        dialogView.findViewById<TextView>(R.id.tv_dialog_message).text = 
+            getString(R.string.reset_custom_app_message_format, appName)
+        
+        val deleteBtn = dialogView.findViewById<Button>(R.id.btn_delete)
+        deleteBtn.text = getString(R.string.reset)
+        deleteBtn.setOnClickListener {
+            onConfirm()
+            dialog.dismiss()
+        }
+
+        dialogView.findViewById<Button>(R.id.btn_cancel).setOnClickListener {
+            dialog.dismiss()
+        }
+
+        dialog.window?.setBackgroundDrawableResource(android.R.color.transparent)
+        dialog.show()
+    }
+
+    private fun showAddCustomAppDialog(appToEdit: CustomApp? = null, isPreloaded: Boolean = false, onSuccess: () -> Unit = {}) {
         val dialogView = layoutInflater.inflate(R.layout.dialog_add_custom_app, null)
         val dialog = AlertDialog.Builder(this)
             .setView(dialogView)
@@ -817,9 +982,14 @@ class AdSilenceActivity : Activity() {
 
         val titleView = dialogView.findViewById<TextView>(R.id.tv_dialog_title)
         if (appToEdit != null) {
-            titleView.text = "Edit Custom App"
+            titleView.text = if (isPreloaded) "Edit App Configuration" else "Edit Custom App"
             dialogView.findViewById<EditText>(R.id.et_app_name).setText(appToEdit.name)
-            dialogView.findViewById<EditText>(R.id.et_package_name).setText(appToEdit.packageName)
+            val pkgEdit = dialogView.findViewById<EditText>(R.id.et_package_name)
+            pkgEdit.setText(appToEdit.packageName)
+            if (isPreloaded) {
+                pkgEdit.isEnabled = false
+                pkgEdit.alpha = 0.5f
+            }
             dialogView.findViewById<EditText>(R.id.et_keywords).setText(appToEdit.keywords.joinToString(", "))
             dialogView.findViewById<EditText>(R.id.et_unmute_delay).setText(appToEdit.unmuteDelay.toString())
         } else {
@@ -831,9 +1001,22 @@ class AdSilenceActivity : Activity() {
             this.movementMethod = LinkMovementMethod.getInstance()
         }
 
+        dialogView.findViewById<EditText>(R.id.et_keywords)?.setOnTouchListener { v, event ->
+            if (v.id == R.id.et_keywords) {
+                val scrollView = dialogView.findViewById<ScrollView>(R.id.sv_content)
+                scrollView.requestDisallowInterceptTouchEvent(true)
+                when (event.action and MotionEvent.ACTION_MASK) {
+                    MotionEvent.ACTION_UP -> scrollView.requestDisallowInterceptTouchEvent(false)
+                }
+            }
+            false
+        }
+
         dialogView.findViewById<Button>(R.id.btn_cancel)?.setOnClickListener {
             dialog.dismiss()
         }
+
+
 
         dialogView.findViewById<Button>(R.id.btn_save)?.setOnClickListener {
             val appName = dialogView.findViewById<EditText>(R.id.et_app_name).text.toString()

--- a/app/src/main/java/bluepie/ad_silence/DefaultAppConfig.kt
+++ b/app/src/main/java/bluepie/ad_silence/DefaultAppConfig.kt
@@ -1,0 +1,28 @@
+package bluepie.ad_silence
+
+import android.content.Context
+import bluepie.ad_silence.triggers.spotifyTrigger
+
+object DefaultAppConfig {
+    fun getDefaultKeywords(app: SupportedApps, context: Context): List<String> {
+        return when (app) {
+            SupportedApps.ACCURADIO -> listOf(context.getString(R.string.accuradio_ad_text))
+            SupportedApps.SPOTIFY, SupportedApps.SPOTIFY_LITE -> listOf(
+                context.getString(R.string.spotify_ad_string),
+                context.getString(R.string.spotify_ad2),
+                *spotifyTrigger
+            )
+            SupportedApps.TIDAL -> listOf(context.getString(R.string.tidal_ad_string))
+            SupportedApps.PANDORA -> listOf(
+                context.getString(R.string.pandora_ad_string),
+                context.getString(R.string.pandora_ad_string_2)
+            )
+            SupportedApps.LiveOne -> listOf(
+                context.getString(R.string.liveOne_ad_string),
+                context.getString(R.string.liveOne_ad_string_2)
+            )
+            SupportedApps.Soundcloud -> listOf(context.getString(R.string.soundcloud_ad_string))
+            else -> emptyList()
+        }
+    }
+}

--- a/app/src/main/java/bluepie/ad_silence/NotificationParser.kt
+++ b/app/src/main/java/bluepie/ad_silence/NotificationParser.kt
@@ -32,44 +32,29 @@ fun AppNotification.getPreloadedAppType(): SupportedApps {
 
 
 fun AppNotification.getApp(): SupportedApps {
+    val preloadedAppType = getPreloadedAppType()
+    if (preloadedAppType != SupportedApps.INVALID) {
+        return preloadedAppType
+    }
+
     val preference = Preference(context)
     val customApps = preference.getCustomApps()
     if (customApps.any { it.packageName == packageName && it.isEnabled }) {
         return SupportedApps.CUSTOM
     }
 
-    return getPreloadedAppType()
+    return SupportedApps.INVALID
 }
 
 fun AppNotification.adString(): List<String> {
-    if (getApp() == SupportedApps.CUSTOM) {
-        val preference = Preference(context)
-        return preference.getCustomApps().find { it.packageName == packageName }?.keywords ?: emptyList()
+    val preference = Preference(context)
+    val customApp = preference.getCustomApps().find { it.packageName == packageName }
+    
+    if (customApp != null) {
+        return customApp.keywords
     }
 
-    return when (getApp()) {
-        SupportedApps.ACCURADIO -> listOf(context.getString(R.string.accuradio_ad_text))
-        SupportedApps.SPOTIFY, SupportedApps.SPOTIFY_LITE -> listOf(
-            context.getString(R.string.spotify_ad_string),
-            context.getString(R.string.spotify_ad2),
-            *spotifyTrigger
-        )
-
-        SupportedApps.TIDAL -> listOf(context.getString(R.string.tidal_ad_string))
-        SupportedApps.PANDORA -> listOf(
-            context.getString(R.string.pandora_ad_string),
-            context.getString(R.string.pandora_ad_string_2)
-        )
-
-        SupportedApps.LiveOne -> listOf(
-            context.getString(R.string.liveOne_ad_string),
-            context.getString(R.string.liveOne_ad_string_2)
-        )
-
-        SupportedApps.Soundcloud -> listOf(context.getString(R.string.soundcloud_ad_string))
-
-        else -> listOf("")
-    }
+    return DefaultAppConfig.getDefaultKeywords(getApp(), context)
 }
 
 interface NotificationParserInterface {

--- a/app/src/main/java/bluepie/ad_silence/Preference.kt
+++ b/app/src/main/java/bluepie/ad_silence/Preference.kt
@@ -94,17 +94,24 @@ class Preference(private val context: Context) {
         }
 
         if(app != SupportedApps.INVALID){
-            val extraInfo = if (app == SupportedApps.CUSTOM && packageName != null) {
+             val extraInfo = if (app == SupportedApps.CUSTOM && packageName != null) {
                 val name = getCustomApps().find { it.packageName == packageName }?.name
                 if (name != null) "($name : $packageName)" else "($packageName)"
             } else if (packageName != null) {
-                 "($packageName)"
+                "($packageName)"
             } else {
                 ""
             }
-            Log.v(TAG, "getting appConfiguration: $app $extraInfo -> $status")
+            Log.v(TAG, "isAppConfigured: $app $extraInfo -> $status")
         }
         return status
+    }
+
+    fun isCustomAppConfigured(app: SupportedApps, packageName: String? = null): Boolean {
+        if (app == SupportedApps.CUSTOM && packageName != null) {
+            return getCustomApps().any { it.packageName == packageName }
+        }
+        return false
     }
 
     fun isNotificationPostingPermissionGranted(): Boolean {

--- a/app/src/main/java/bluepie/ad_silence/Utils.kt
+++ b/app/src/main/java/bluepie/ad_silence/Utils.kt
@@ -103,15 +103,18 @@ class Utils {
     }
 
     fun getUnmuteDelay(app: SupportedApps, packageName: String? = null, preference: Preference? = null): Long {
-        if (app == SupportedApps.CUSTOM && packageName != null && preference != null) {
-            return preference.getCustomApps().find { it.packageName == packageName }?.unmuteDelay ?: 0
-        }
-        return when (app) {
-            SupportedApps.SPOTIFY_LITE -> 540
-            SupportedApps.SPOTIFY -> 480
-            else -> 0
+    if (preference != null && packageName != null) {
+        val delay = preference.getCustomApps().find { it.packageName == packageName }?.unmuteDelay
+        if (delay != null) {
+             return delay
         }
     }
+    return when (app) {
+        SupportedApps.SPOTIFY_LITE -> 540
+        SupportedApps.SPOTIFY -> 480
+        else -> 0
+    }
+}
 
     fun unmute(
         audioManager: AudioManager?,

--- a/app/src/main/res/drawable/ic_restore.xml
+++ b/app/src/main/res/drawable/ic_restore.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+  <path
+      android:fillColor="#FF808080"
+      android:pathData="M12,5V1L7,6l5,5V7c3.31,0 6,2.69 6,6s-2.69,6 -6,6 -6,-2.69 -6,-6H4c0,4.42 3.58,8 8,8s8,-3.58 8,-8 -3.58,-8 -8,-8z"/>
+</vector>

--- a/app/src/main/res/layout/app_selection.xml
+++ b/app/src/main/res/layout/app_selection.xml
@@ -28,61 +28,292 @@
             android:layout_height="wrap_content"
             android:orientation="vertical">
 
-            <Switch
-                android:id="@+id/accuradio_selection_switch"
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:minHeight="48dp"
-                android:text="@string/accuradio"
-                android:textColor="?android:attr/textColorPrimary" />
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
 
-            <Switch
-                android:id="@+id/spotify_selection_switch"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:minHeight="48dp"
-                android:text="@string/spotify"
-                android:textColor="?android:attr/textColorPrimary" />
+                <TextView
+                    android:id="@+id/tv_accuradio"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/accuradio"
+                    android:textColor="?android:attr/textColorPrimary" />
 
-            <Switch
-                android:id="@+id/spotify_lite_selection_switch"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:minHeight="48dp"
-                android:text="@string/spotify_lite"
-                android:textColor="?android:attr/textColorPrimary" />
+                <ImageView
+                    android:id="@+id/accuradio_reset_btn"
+                    android:layout_width="48dp"
+                    android:layout_height="48dp"
+                    android:background="?android:attr/selectableItemBackgroundBorderless"
+                    android:padding="12dp"
+                    android:src="@drawable/ic_restore"
+                    android:contentDescription="Reset"
+                    android:visibility="gone"
+                    android:layout_marginEnd="4dp"/>
 
-            <Switch
-                android:id="@+id/soundcloud_selection_switch"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:minHeight="48dp"
-                android:text="@string/soundcloud"
-                android:textColor="?android:attr/textColorPrimary" />
+                <ImageView
+                    android:id="@+id/accuradio_edit_btn"
+                    android:layout_width="48dp"
+                    android:layout_height="48dp"
+                    android:background="?android:attr/selectableItemBackgroundBorderless"
+                    android:padding="16px"
+                    android:src="@drawable/ic_edit"
+                    android:contentDescription="Edit" />
 
-            <Switch
-                android:id="@+id/tidal_selection_switch"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:minHeight="48dp"
-                android:text="@string/tidal"
-                android:textColor="?android:attr/textColorPrimary" />
+                <Switch
+                    android:id="@+id/accuradio_selection_switch"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:minHeight="48dp" />
+            </LinearLayout>
 
-            <Switch
-                android:id="@+id/pandora_selection_switch"
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:minHeight="48dp"
-                android:text="@string/pandora"
-                android:textColor="?android:attr/textColorPrimary" />
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
 
-            <Switch
-                android:id="@+id/liveone_selection_switch"
+                <TextView
+                    android:id="@+id/tv_spotify"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/spotify"
+                    android:textColor="?android:attr/textColorPrimary" />
+
+                <ImageView
+                    android:id="@+id/spotify_reset_btn"
+                    android:layout_width="48dp"
+                    android:layout_height="48dp"
+                    android:background="?android:attr/selectableItemBackgroundBorderless"
+                    android:padding="12dp"
+                    android:src="@drawable/ic_restore"
+                    android:contentDescription="Reset"
+                    android:visibility="gone"
+                    android:layout_marginEnd="4dp"/>
+
+                <ImageView
+                    android:id="@+id/spotify_edit_btn"
+                    android:layout_width="48dp"
+                    android:layout_height="48dp"
+                    android:background="?android:attr/selectableItemBackgroundBorderless"
+                    android:padding="16px"
+                    android:src="@drawable/ic_edit"
+                    android:contentDescription="Edit" />
+
+                <Switch
+                    android:id="@+id/spotify_selection_switch"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:minHeight="48dp" />
+            </LinearLayout>
+
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:minHeight="48dp"
-                android:text="@string/liveone"
-                android:textColor="?android:attr/textColorPrimary" />
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:id="@+id/tv_spotify_lite"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/spotify_lite"
+                    android:textColor="?android:attr/textColorPrimary" />
+
+                <ImageView
+                    android:id="@+id/spotify_lite_reset_btn"
+                    android:layout_width="48dp"
+                    android:layout_height="48dp"
+                    android:background="?android:attr/selectableItemBackgroundBorderless"
+                    android:padding="12dp"
+                    android:src="@drawable/ic_restore"
+                    android:contentDescription="Reset"
+                    android:visibility="gone"
+                    android:layout_marginEnd="4dp"/>
+
+                <ImageView
+                    android:id="@+id/spotify_lite_edit_btn"
+                    android:layout_width="48dp"
+                    android:layout_height="48dp"
+                    android:background="?android:attr/selectableItemBackgroundBorderless"
+                    android:padding="16px"
+                    android:src="@drawable/ic_edit"
+                    android:contentDescription="Edit" />
+
+                <Switch
+                    android:id="@+id/spotify_lite_selection_switch"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:minHeight="48dp" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:id="@+id/tv_soundcloud"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/soundcloud"
+                    android:textColor="?android:attr/textColorPrimary" />
+
+                <ImageView
+                    android:id="@+id/soundcloud_reset_btn"
+                    android:layout_width="48dp"
+                    android:layout_height="48dp"
+                    android:background="?android:attr/selectableItemBackgroundBorderless"
+                    android:padding="12dp"
+                    android:src="@drawable/ic_restore"
+                    android:contentDescription="Reset"
+                    android:visibility="gone"
+                    android:layout_marginEnd="4dp"/>
+
+                <ImageView
+                    android:id="@+id/soundcloud_edit_btn"
+                    android:layout_width="48dp"
+                    android:layout_height="48dp"
+                    android:background="?android:attr/selectableItemBackgroundBorderless"
+                    android:padding="16px"
+                    android:src="@drawable/ic_edit"
+                    android:contentDescription="Edit" />
+
+                <Switch
+                    android:id="@+id/soundcloud_selection_switch"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:minHeight="48dp" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:id="@+id/tv_tidal"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/tidal"
+                    android:textColor="?android:attr/textColorPrimary" />
+
+                <ImageView
+                    android:id="@+id/tidal_reset_btn"
+                    android:layout_width="48dp"
+                    android:layout_height="48dp"
+                    android:background="?android:attr/selectableItemBackgroundBorderless"
+                    android:padding="12dp"
+                    android:src="@drawable/ic_restore"
+                    android:contentDescription="Reset"
+                    android:visibility="gone"
+                    android:layout_marginEnd="4dp"/>
+
+                <ImageView
+                    android:id="@+id/tidal_edit_btn"
+                    android:layout_width="48dp"
+                    android:layout_height="48dp"
+                    android:background="?android:attr/selectableItemBackgroundBorderless"
+                    android:padding="16px"
+                    android:src="@drawable/ic_edit"
+                    android:contentDescription="Edit" />
+
+                <Switch
+                    android:id="@+id/tidal_selection_switch"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:minHeight="48dp" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:id="@+id/tv_pandora"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/pandora"
+                    android:textColor="?android:attr/textColorPrimary" />
+
+                <ImageView
+                    android:id="@+id/pandora_reset_btn"
+                    android:layout_width="48dp"
+                    android:layout_height="48dp"
+                    android:background="?android:attr/selectableItemBackgroundBorderless"
+                    android:padding="12dp"
+                    android:src="@drawable/ic_restore"
+                    android:contentDescription="Reset"
+                    android:visibility="gone"
+                    android:layout_marginEnd="4dp"/>
+
+                <ImageView
+                    android:id="@+id/pandora_edit_btn"
+                    android:layout_width="48dp"
+                    android:layout_height="48dp"
+                    android:background="?android:attr/selectableItemBackgroundBorderless"
+                    android:padding="16px"
+                    android:src="@drawable/ic_edit"
+                    android:contentDescription="Edit" />
+
+                <Switch
+                    android:id="@+id/pandora_selection_switch"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:minHeight="48dp" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:id="@+id/tv_liveone"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/liveone"
+                    android:textColor="?android:attr/textColorPrimary" />
+
+                <ImageView
+                    android:id="@+id/liveone_reset_btn"
+                    android:layout_width="48dp"
+                    android:layout_height="48dp"
+                    android:background="?android:attr/selectableItemBackgroundBorderless"
+                    android:padding="12dp"
+                    android:src="@drawable/ic_restore"
+                    android:contentDescription="Reset"
+                    android:visibility="gone"
+                    android:layout_marginEnd="4dp"/>
+
+                <ImageView
+                    android:id="@+id/liveone_edit_btn"
+                    android:layout_width="48dp"
+                    android:layout_height="48dp"
+                    android:background="?android:attr/selectableItemBackgroundBorderless"
+                    android:padding="16px"
+                    android:src="@drawable/ic_edit"
+                    android:contentDescription="Edit" />
+
+                <Switch
+                    android:id="@+id/liveone_selection_switch"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:minHeight="48dp" />
+            </LinearLayout>
 
             <LinearLayout
                 android:id="@+id/custom_apps_container"

--- a/app/src/main/res/layout/dialog_add_custom_app.xml
+++ b/app/src/main/res/layout/dialog_add_custom_app.xml
@@ -17,184 +17,201 @@
         android:textSize="20sp"
         android:textStyle="bold" />
 
-    <LinearLayout
+    <ScrollView
+        android:id="@+id/sv_content"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="16dp"
-        android:orientation="vertical">
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:layout_marginBottom="16dp">
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="4dp"
-            android:layout_marginLeft="16dp"
-            android:layout_marginStart="16dp"
-            android:text="@string/app_name_label"
-            android:textColor="?android:attr/textColorSecondary"
-            android:textSize="12sp" />
-
-        <EditText
-            android:id="@+id/et_app_name"
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="@drawable/bg_edit_text"
-            android:hint=""
-            android:inputType="text"
-            android:textColor="?android:attr/textColorPrimary"
-            android:textColorHint="?android:attr/textColorHint"
-            android:textSize="16sp" />
+            android:orientation="vertical">
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="4dp"
-            android:layout_marginLeft="16dp"
-            android:layout_marginStart="16dp"
-            android:text="@string/app_name_hint"
-            android:textColor="?android:attr/textColorSecondary"
-            android:textSize="12sp" />
-    </LinearLayout>
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
+                android:orientation="vertical">
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="16dp"
-        android:orientation="vertical">
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="4dp"
+                    android:layout_marginLeft="16dp"
+                    android:layout_marginStart="16dp"
+                    android:text="@string/app_name_label"
+                    android:textColor="?android:attr/textColorSecondary"
+                    android:textSize="12sp" />
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="4dp"
-            android:layout_marginLeft="16dp"
-            android:layout_marginStart="16dp"
-            android:text="@string/package_name_label"
-            android:textColor="?android:attr/textColorSecondary"
-            android:textSize="12sp" />
+                <EditText
+                    android:id="@+id/et_app_name"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/bg_edit_text"
+                    android:hint=""
+                    android:inputType="text"
+                    android:textColor="?android:attr/textColorPrimary"
+                    android:textColorHint="?android:attr/textColorHint"
+                    android:textSize="16sp" />
 
-        <EditText
-            android:id="@+id/et_package_name"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="@drawable/bg_edit_text"
-            android:hint="@string/package_name_label"
-            android:inputType="text"
-            android:textColor="?android:attr/textColorPrimary"
-            android:textColorHint="?android:attr/textColorHint"
-            android:textSize="16sp" />
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:layout_marginLeft="16dp"
+                    android:layout_marginStart="16dp"
+                    android:text="@string/app_name_hint"
+                    android:textColor="?android:attr/textColorSecondary"
+                    android:textSize="12sp" />
+            </LinearLayout>
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="4dp"
-            android:layout_marginLeft="16dp"
-            android:layout_marginStart="16dp"
-            android:text="@string/package_name_hint"
-            android:textColor="?android:attr/textColorSecondary"
-            android:textSize="12sp" />
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
+                android:orientation="vertical">
 
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:layout_marginBottom="4dp"
-            android:layout_marginLeft="16dp"
-            android:layout_marginStart="16dp"
-            android:layout_marginRight="16dp"
-            android:layout_marginEnd="16dp"
-            android:text="@string/custom_app_overlay_hint"
-            android:textColor="?android:attr/textColorSecondary"
-            android:textStyle="italic"
-            android:textSize="11sp" />
-    </LinearLayout>
-    
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="16dp"
-        android:orientation="vertical">
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="4dp"
+                    android:layout_marginLeft="16dp"
+                    android:layout_marginStart="16dp"
+                    android:text="@string/package_name_label"
+                    android:textColor="?android:attr/textColorSecondary"
+                    android:textSize="12sp" />
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="4dp"
-            android:layout_marginLeft="16dp"
-            android:layout_marginStart="16dp"
-            android:text="Unmute Delay (ms)"
-            android:textColor="?android:attr/textColorSecondary"
-            android:textSize="12sp" />
+                <EditText
+                    android:id="@+id/et_package_name"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/bg_edit_text"
+                    android:hint="@string/package_name_label"
+                    android:inputType="text"
+                    android:textColor="?android:attr/textColorPrimary"
+                    android:textColorHint="?android:attr/textColorHint"
+                    android:textSize="16sp" />
 
-        <EditText
-            android:id="@+id/et_unmute_delay"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="@drawable/bg_edit_text"
-            android:hint="0"
-            android:inputType="number"
-            android:textColor="?android:attr/textColorPrimary"
-            android:textColorHint="?android:attr/textColorHint"
-            android:textSize="16sp" />
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:layout_marginLeft="16dp"
+                    android:layout_marginStart="16dp"
+                    android:text="@string/package_name_hint"
+                    android:textColor="?android:attr/textColorSecondary"
+                    android:textSize="12sp" />
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="4dp"
-            android:layout_marginLeft="16dp"
-            android:layout_marginStart="16dp"
-            android:text="Delay in milliseconds before unmuting (0 for instant)"
-            android:textColor="?android:attr/textColorSecondary"
-            android:textSize="12sp" />
-    </LinearLayout>
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:layout_marginBottom="4dp"
+                    android:layout_marginLeft="16dp"
+                    android:layout_marginStart="16dp"
+                    android:layout_marginRight="16dp"
+                    android:layout_marginEnd="16dp"
+                    android:text="@string/custom_app_overlay_hint"
+                    android:textColor="?android:attr/textColorSecondary"
+                    android:textStyle="italic"
+                    android:textSize="11sp" />
+            </LinearLayout>
+            
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
+                android:orientation="vertical">
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="16dp"
-        android:orientation="vertical">
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="4dp"
+                    android:layout_marginLeft="16dp"
+                    android:layout_marginStart="16dp"
+                    android:text="Unmute Delay (ms)"
+                    android:textColor="?android:attr/textColorSecondary"
+                    android:textSize="12sp" />
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="4dp"
-            android:layout_marginLeft="16dp"
-            android:layout_marginStart="16dp"
-            android:text="@string/keywords_label"
-            android:textColor="?android:attr/textColorSecondary"
-            android:textSize="12sp" />
+                <EditText
+                    android:id="@+id/et_unmute_delay"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/bg_edit_text"
+                    android:hint="0"
+                    android:inputType="number"
+                    android:textColor="?android:attr/textColorPrimary"
+                    android:textColorHint="?android:attr/textColorHint"
+                    android:textSize="16sp" />
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="4dp"
-            android:layout_marginLeft="16dp"
-            android:layout_marginStart="16dp"
-            android:text="@string/keywords_description"
-            android:textColor="?android:attr/textColorSecondary"
-            android:textSize="12sp" />
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:layout_marginLeft="16dp"
+                    android:layout_marginStart="16dp"
+                    android:text="Delay in milliseconds before unmuting (0 for instant)"
+                    android:textColor="?android:attr/textColorSecondary"
+                    android:textSize="12sp" />
+            </LinearLayout>
 
-        <EditText
-            android:id="@+id/et_keywords"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="@drawable/bg_edit_text"
-            android:gravity="top|start"
-            android:hint="@string/keywords_hint"
-            android:inputType="textMultiLine"
-            android:minLines="3"
-            android:padding="16dp"
-            android:textColor="?android:attr/textColorPrimary"
-            android:textColorHint="?android:attr/textColorHint"
-            android:textSize="16sp" />
-    </LinearLayout>
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
+                android:orientation="vertical">
 
-    <TextView
-        android:id="@+id/tv_help_link"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="24dp"
-        android:gravity="center"
-        android:text="@string/custom_app_help_text"
-        android:textColor="?android:attr/textColorSecondary"
-        android:textSize="12sp" />
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="4dp"
+                    android:layout_marginLeft="16dp"
+                    android:layout_marginStart="16dp"
+                    android:text="@string/keywords_label"
+                    android:textColor="?android:attr/textColorSecondary"
+                    android:textSize="12sp" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="4dp"
+                    android:layout_marginLeft="16dp"
+                    android:layout_marginStart="16dp"
+                    android:text="@string/keywords_description"
+                    android:textColor="?android:attr/textColorSecondary"
+                    android:textSize="12sp" />
+
+                <EditText
+                    android:id="@+id/et_keywords"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:minHeight="150dp"
+                    android:maxHeight="300dp"
+                    android:background="@drawable/bg_edit_text"
+                    android:gravity="top|start"
+                    android:hint="@string/keywords_hint"
+                    android:inputType="textMultiLine"
+                    android:scrollbars="vertical"
+                    android:padding="16dp"
+                    android:textColor="?android:attr/textColorPrimary"
+                    android:textColorHint="?android:attr/textColorHint"
+                    android:textSize="16sp" />
+            </LinearLayout>
+
+            <TextView
+                android:id="@+id/tv_help_link"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="24dp"
+                android:gravity="center"
+                android:text="@string/custom_app_help_text"
+                android:textColor="?android:attr/textColorSecondary"
+                android:textSize="12sp" />
+
+        </LinearLayout>
+    </ScrollView>
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -74,6 +74,9 @@
     <string name="channel_name">Stato del servizio</string>
     <string name="channel_description">Notifica persistente che mostra che AdSilence è attivo</string>
     <string name="notification_update_help">Se il silenziamento o il rilevamento non funzionano, prova ad abilitare questa opzione.</string>
-    <string name="force_mute_title">Force Mute (Don\'t check existing mute)</string>
-    <string name="force_mute_desc">Mute ads without checking if the media is already muted.</string>
+    <string name="force_mute_title">Forza Muto (non controllare il muto esistente)</string>
+    <string name="force_mute_desc">Disattiva gli annunci senza verificare se i media sono già disattivati.</string>
+    <string name="reset">Ripristina</string>
+    <string name="reset_app_configuration">Ripristina configurazione app</string>
+    <string name="reset_custom_app_message_format">Sei sicuro? Le tue modifiche per %1$s verranno ripristinate ai valori predefiniti.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -78,6 +78,7 @@
 
     <!-- Custom App Dialog Strings -->
     <string name="add_custom_app">Add Custom App</string>
+    <string name="reset">Reset</string>
     <string name="custom_app_help_text">Not sure what to put? <![CDATA[<a href="https://github.com/aghontpi/ad-silence/wiki/Custom_App_Wiki">View guide here!</a>]]></string>
     <string name="custom_app_overlay_hint">Tip: Use the package name of a pre-configured app (like Spotify) to add extra ad-blocking keywords.</string>
     <string name="custom_app_list_hint">Missed ads? For existing preconfigured apps, you can also use \'Add Custom App\' below to define new detection keywords.</string>
@@ -113,4 +114,6 @@
     <string name="mute_behavior_help">Not sure which one to choose? <![CDATA[<a href="https://github.com/aghontpi/ad-silence/wiki/Mute%E2%80%90behaviour%E2%80%90settings">Read here!</a>]]></string>
     <string name="force_mute_title">Force Mute (Don\'t check existing mute)</string>
     <string name="force_mute_desc">Mute ads without checking if the media is already muted.</string>
+    <string name="reset_app_configuration">Reset App Configuration</string>
+    <string name="reset_custom_app_message_format">Are you sure? Your changes for %1$s will be reset to default.</string>
 </resources>


### PR DESCRIPTION
This **PR** makes the following changes.

- Adds ability to edit preloaded apps.
- Refines preloaded app configuration to prevent duplicates in the custom list and adds a reset functionality.
<img width="260" height="auto" alt="Screenshot 2025-12-26 at 1 30 02 AM" src="https://github.com/user-attachments/assets/d6777724-4f51-40bc-bcf6-c544541104fa" />
<img width="260" height="auto" alt="Screenshot 2025-12-26 at 1 30 09 AM" src="https://github.com/user-attachments/assets/f9af8a13-1820-4abc-8206-3320c21394d0" />
<img width="260" height="auto" alt="Screenshot 2025-12-26 at 1 30 18 AM" src="https://github.com/user-attachments/assets/cf2c8a6b-c8bc-4d29-9f78-5464baef58d2" />

