### PR TITLE
feat: move casting under settings

### DIFF
--- a/app/src/main/java/bluepie/ad_silence/AdSilenceActivity.kt
+++ b/app/src/main/java/bluepie/ad_silence/AdSilenceActivity.kt
@@ -1280,6 +1280,13 @@ class AdSilenceActivity : Activity() {
             mediaRouter = applicationContext.getSystemService(Context.MEDIA_ROUTER_SERVICE) as MediaRouter
 
             fun updateCastingStatus() {
+                val preference = Preference(applicationContext)
+                if (!preference.isCastingMuteEnabled()) {
+                    castingStatusTextView?.text = "Casting settings turned off"
+                    castingStatusTextView?.visibility = View.VISIBLE
+                    return
+                }
+
                 val route = mediaRouter?.getSelectedRoute(MediaRouter.ROUTE_TYPE_LIVE_AUDIO)
                 Log.v(TAG, "DebugDialog: Current route: ${route?.name}, type: ${route?.playbackType}, desc: ${route?.description}")
                 
@@ -1439,6 +1446,23 @@ class AdSilenceActivity : Activity() {
                         isAd = false,
                         title = "Setting Changed",
                         text = "Force Mute: $isChecked",
+                        subText = "Settings"
+                    ))
+                }
+            }
+        }
+
+        dialogView.findViewById<Switch>(R.id.switch_casting_mute)?.apply {
+            isChecked = preference.isCastingMuteEnabled()
+            setOnCheckedChangeListener { _, isChecked ->
+                preference.setCastingMuteEnabled(isChecked)
+                if (preference.isDebugLogEnabled()) {
+                    LogManager.addLog(LogEntry(
+                        appName = "AdSilence",
+                        timestamp = System.currentTimeMillis(),
+                        isAd = false,
+                        title = "Setting Changed",
+                        text = "Casting Mute: $isChecked",
                         subText = "Settings"
                     ))
                 }

--- a/app/src/main/java/bluepie/ad_silence/CastMuteManager.kt
+++ b/app/src/main/java/bluepie/ad_silence/CastMuteManager.kt
@@ -8,8 +8,13 @@ import android.util.Log
 class CastMuteManager(private val context: Context) {
     private val TAG = "CastMuteManager"
     private var isMutedByManager = false
-
     private var originalVolume = -1
+
+    fun resetState() {
+        Log.v(TAG, "Resetting state")
+        isMutedByManager = false
+        originalVolume = -1
+    }
 
     fun tryMute(notificationListener: NotificationListener): Boolean {
         val controller = notificationListener.getMediaControllerForCasting()

--- a/app/src/main/java/bluepie/ad_silence/NotificationListener.kt
+++ b/app/src/main/java/bluepie/ad_silence/NotificationListener.kt
@@ -303,24 +303,25 @@ class NotificationListener : NotificationListenerService() {
                                     
                                     // Check for casting
                                     val route = currentRoute
-                                    var isCasting = route != null && route.playbackType == MediaRouter.RouteInfo.PLAYBACK_TYPE_REMOTE
-                                    var castController: android.media.session.MediaController? = null
-
-                                    // Fallback: If MediaRouter says local, check notifications for a casting token
-                                    if (!isCasting) {
-                                        castController = getMediaControllerForCasting()
-                                        if (castController != null) {
-                                            isCasting = true
-                                            Log.v(TAG, "Casting detected via Notification Fallback")
-                                            if (isDebugEnabled) {
-                                                LogManager.addLifecycleLog(LogEntry(
-                                                    appName = "AdSilence",
-                                                    timestamp = System.currentTimeMillis(),
-                                                    isAd = true,
-                                                    title = "Casting Detected",
-                                                    text = "Casting session detected via Notification Fallback",
-                                                    subText = "Detection"
-                                                ))
+                                    var isCasting = false
+                                    if (preference.isCastingMuteEnabled()) {
+                                        isCasting = route != null && route.playbackType == MediaRouter.RouteInfo.PLAYBACK_TYPE_REMOTE
+                                        // Fallback: If MediaRouter says local, check notifications for a casting token
+                                        if (!isCasting) {
+                                            val castController = getMediaControllerForCasting()
+                                            if (castController != null) {
+                                                isCasting = true
+                                                Log.v(TAG, "Casting detected via Notification Fallback")
+                                                if (isDebugEnabled) {
+                                                    LogManager.addLifecycleLog(LogEntry(
+                                                        appName = "AdSilence",
+                                                        timestamp = System.currentTimeMillis(),
+                                                        isAd = true,
+                                                        title = "Casting Detected",
+                                                        text = "Casting session detected via Notification Fallback",
+                                                        subText = "Detection"
+                                                    ))
+                                                }
                                             }
                                         }
                                     }
@@ -352,11 +353,7 @@ class NotificationListener : NotificationListenerService() {
                                                 }
                                             }
                                         } else {
-                                            if (castMuteManager.tryMute(this@NotificationListener)) {
-                                                Log.v(TAG, "Muted via CastMuteManager")
-                                            } else {
-                                                this.mute(audioManager, appNotificationHelper, preference)
-                                            }
+                                            this.mute(audioManager, appNotificationHelper, preference)
                                         }
                                         
                                         if (isDebugEnabled) {
@@ -408,16 +405,13 @@ class NotificationListener : NotificationListenerService() {
                                                                 }
                                                             }
                                                         } else {
-                                                            if (castMuteManager.tryUnmute(this@NotificationListener)) {
-                                                                Log.v(TAG, "Unmuted via CastMuteManager (< M)")
-                                                            } else {
-                                                                this@run.unmute(
-                                                                    audioManager,
-                                                                    appNotificationHelper,
-                                                                    currentPackage,
-                                                                    preference
-                                                                )
-                                                            }
+                                                            castMuteManager.resetState()
+                                                            unmute(
+                                                                audioManager,
+                                                                appNotificationHelper,
+                                                                currentPackage,
+                                                                preference
+                                                            )
                                                         }
                                                         muteCount--
                                                     }
@@ -444,10 +438,8 @@ class NotificationListener : NotificationListenerService() {
                                                              }
                                                          }
                                                     } else {
-                                                        if (castMuteManager.tryUnmute(this@NotificationListener)) {
-                                                            Log.v(TAG, "Unmuted via CastMuteManager (> M)")
-                                                        } else {
-                                                            this@run.unmute(
+                                                            castMuteManager.resetState()
+                                                            unmute(
                                                                 audioManager,
                                                                 appNotificationHelper,
                                                                 currentPackage,
@@ -456,7 +448,7 @@ class NotificationListener : NotificationListenerService() {
                                                         }
                                                     }
                                                     isMuted = false
-                                                }
+
                                                 if (isDebugEnabled) {
                                                     LogManager.addLifecycleLog(LogEntry(
                                                         appName = "AdSilence",

--- a/app/src/main/java/bluepie/ad_silence/Preference.kt
+++ b/app/src/main/java/bluepie/ad_silence/Preference.kt
@@ -199,6 +199,20 @@ class Preference(private val context: Context) {
         }
     }
 
+    private val CASTING_MUTE_ENABLED = "CastingMuteEnabled"
+    private val CASTING_MUTE_ENABLED_DEFAULT = true
+
+    fun isCastingMuteEnabled(): Boolean {
+        return preference.getBoolean(CASTING_MUTE_ENABLED, CASTING_MUTE_ENABLED_DEFAULT)
+    }
+
+    fun setCastingMuteEnabled(status: Boolean) {
+        Log.v(TAG, "[configCastingMuteEnabled] ${isCastingMuteEnabled()} -> $status")
+        preference.edit {
+            putBoolean(CASTING_MUTE_ENABLED, status).commit()
+        }
+    }
+
     private val CUSTOM_APPS = "CustomApps"
 
     companion object {

--- a/app/src/main/res/layout/dialog_settings.xml
+++ b/app/src/main/res/layout/dialog_settings.xml
@@ -112,6 +112,43 @@
 
         </LinearLayout>
 
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:layout_marginTop="16dp">
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/casting_mute_title"
+                    android:textColor="?android:attr/textColorPrimary"
+                    android:textSize="14sp" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/casting_mute_desc"
+                    android:textColor="?android:attr/textColorSecondary"
+                    android:textSize="12sp" />
+
+            </LinearLayout>
+
+            <Switch
+                android:id="@+id/switch_casting_mute"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp" />
+            
+        </LinearLayout>
+
     </LinearLayout>
 
     <Button

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -76,6 +76,10 @@
     <string name="notification_update_help">Se il silenziamento o il rilevamento non funzionano, prova ad abilitare questa opzione.</string>
     <string name="force_mute_title">Forza Muto (non controllare il muto esistente)</string>
     <string name="force_mute_desc">Disattiva gli annunci senza verificare se i media sono già disattivati.</string>
+
+    <string name="casting_mute_title">Trasmissione</string>
+    <string name="casting_mute_desc">Disattiva audio annunci durante la trasmissione su altri dispositivi (es. Google Home, Chromecast).</string>
+
     <string name="reset">Ripristina</string>
     <string name="reset_app_configuration">Ripristina configurazione app</string>
     <string name="reset_custom_app_message_format">Sei sicuro? Le tue modifiche per %1$s verranno ripristinate ai valori predefiniti.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -114,6 +114,10 @@
     <string name="mute_behavior_help">Not sure which one to choose? <![CDATA[<a href="https://github.com/aghontpi/ad-silence/wiki/Mute%E2%80%90behaviour%E2%80%90settings">Read here!</a>]]></string>
     <string name="force_mute_title">Force Mute (Don\'t check existing mute)</string>
     <string name="force_mute_desc">Mute ads without checking if the media is already muted.</string>
+
+    <string name="casting_mute_title">Casting</string>
+    <string name="casting_mute_desc">Mute ads while casting to other devices (e.g. Google Home, Chromecast).</string>
+
     <string name="reset_app_configuration">Reset App Configuration</string>
     <string name="reset_custom_app_message_format">Are you sure? Your changes for %1$s will be reset to default.</string>
 </resources>


### PR DESCRIPTION
Added a setting to enable/disable casting mute functionality.

Added new settings option
<img width="868" height="862" alt="Screenshot_20260103-004834" src="https://github.com/user-attachments/assets/170e56ca-8fd1-485f-84f1-34dbd8ff3c52" />

If cast settings is turned on
<img width="1059" height="455" alt="Screenshot_20260103-004839" src="https://github.com/user-attachments/assets/e735ecfa-9634-4976-955d-b334b8d636fd" />

if cast settings is turned off, any cast detections that is on.. will be turned off and behave like how its been before the cast option was added.
<img width="1080" height="416" alt="Screenshot_20260103-004847" src="https://github.com/user-attachments/assets/5962ea8b-1256-4df3-90ab-7a787acb6d93" />



