### PR TITLE
Fix(MIUI): Auto-restart notification listener & Autostart dialog

### DIFF
--- a/app/src/main/java/bluepie/ad_silence/AdSilenceActivity.kt
+++ b/app/src/main/java/bluepie/ad_silence/AdSilenceActivity.kt
@@ -36,6 +36,7 @@ class AdSilenceActivity : Activity() {
     private var addCustomAppDialog: AlertDialog? = null
     private var deleteCustomAppDialog: AlertDialog? = null
     private var settingsDialog: AlertDialog? = null
+    private var miuiAutostartDialog: AlertDialog? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -59,6 +60,7 @@ class AdSilenceActivity : Activity() {
         // handleHibernation()
         configureViewsWithLinks()
         configureBatteryOptimization()
+        checkAndPromptForMiuiAutostart()
     }
 
     override fun onDestroy() {
@@ -90,6 +92,11 @@ class AdSilenceActivity : Activity() {
         if (settingsDialog != null && settingsDialog!!.isShowing) {
             Log.v(TAG, "Dismissing settings dialog")
             settingsDialog!!.dismiss()
+        }
+
+        if (miuiAutostartDialog != null && miuiAutostartDialog!!.isShowing) {
+            Log.v(TAG, "Dismissing miui autostart dialog")
+            miuiAutostartDialog!!.dismiss()
         }
     }
 
@@ -1542,6 +1549,75 @@ class AdSilenceActivity : Activity() {
         settingsDialog = dialog
         dialog.setOnDismissListener {
             settingsDialog = null
+        }
+        dialog.show()
+    }
+
+
+    private fun isXiaomi(): Boolean {
+        return Build.MANUFACTURER.equals("xiaomi", ignoreCase = true) ||
+               Build.MANUFACTURER.equals("redmi", ignoreCase = true) ||
+               Build.MANUFACTURER.equals("poco", ignoreCase = true)
+    }
+
+    private fun checkAndPromptForMiuiAutostart() {
+        if (!isXiaomi()) return
+        
+        val preference = Preference(applicationContext)
+        // Only checking if
+        // 1. App is enabled
+        // 2. Notification permission is granted (so we expect service to run)
+        // 3. Service instance is null (it's not running)
+        
+        if (preference.isEnabled() && 
+            checkNotificationListenerPermission(applicationContext) && 
+            NotificationListener.instance == null) {
+                
+            Log.v(TAG, "MIUI Device detected & Service not running. Prompting Autostart.")
+            showMiuiAutostartDialog()
+        }
+    }
+
+    private fun showMiuiAutostartDialog() {
+        if (miuiAutostartDialog != null && miuiAutostartDialog!!.isShowing) {
+            return
+        }
+
+        val dialogView = layoutInflater.inflate(R.layout.dialog_delete_custom_app, null) // Reuse generic dialog layout
+        val dialog = AlertDialog.Builder(this)
+            .setView(dialogView)
+            .create()
+
+        dialogView.findViewById<TextView>(R.id.tv_dialog_title).text = getString(R.string.miui_autostart_title)
+        dialogView.findViewById<TextView>(R.id.tv_dialog_message).text = getString(R.string.miui_autostart_message)
+        
+        val openSettingsBtn = dialogView.findViewById<Button>(R.id.btn_delete)
+        openSettingsBtn.text = getString(R.string.miui_autostart_button)
+        openSettingsBtn.setOnClickListener {
+            try {
+                val intent = Intent()
+                intent.component = android.content.ComponentName(
+                    "com.miui.securitycenter",
+                    "com.miui.permcenter.autostart.AutoStartManagementActivity"
+                )
+                startActivity(intent)
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to open MIUI Autostart settings", e)
+                Toast.makeText(this, "Could not open Autostart settings directly. Please go to Autostart settings and enable it manually.", Toast.LENGTH_LONG).show()
+            }
+            dialog.dismiss()
+        }
+
+        val ignoreBtn = dialogView.findViewById<Button>(R.id.btn_cancel)
+        ignoreBtn.text = getString(R.string.miui_autostart_ignore)
+        ignoreBtn.setOnClickListener {
+            dialog.dismiss()
+        }
+
+        dialog.window?.setBackgroundDrawableResource(android.R.color.transparent)
+        miuiAutostartDialog = dialog
+        dialog.setOnDismissListener {
+            miuiAutostartDialog = null
         }
         dialog.show()
     }

--- a/app/src/main/java/bluepie/ad_silence/AdSilenceActivity.kt
+++ b/app/src/main/java/bluepie/ad_silence/AdSilenceActivity.kt
@@ -37,6 +37,7 @@ class AdSilenceActivity : Activity() {
     private var deleteCustomAppDialog: AlertDialog? = null
     private var settingsDialog: AlertDialog? = null
     private var miuiAutostartDialog: AlertDialog? = null
+    private var hasOpenedAutostartSettings: Boolean = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -254,37 +255,7 @@ class AdSilenceActivity : Activity() {
             
             if (toChange) {
                 // Turning ON
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                    Log.v(TAG, "Toggling ON: Requesting Rebind (API >= 24)")
-                    if (preference.isDebugLogEnabled()) {
-                        LogManager.addLifecycleLog(LogEntry(
-                            appName = "AdSilence",
-                            timestamp = System.currentTimeMillis(),
-                            isAd = false,
-                            title = "Service Rebind",
-                            text = "Toggling ON: Requesting Rebind (API >= 24)",
-                            subText = "Lifecycle Event"
-                        ))
-                    }
-                    android.service.notification.NotificationListenerService.requestRebind(
-                        android.content.ComponentName(this, NotificationListener::class.java)
-                    )
-                } else {
-                    Log.v(TAG, "Toggling ON: Sending START_SERVICE intent (API < 24)")
-                    if (preference.isDebugLogEnabled()) {
-                        LogManager.addLifecycleLog(LogEntry(
-                            appName = "AdSilence",
-                            timestamp = System.currentTimeMillis(),
-                            isAd = false,
-                            title = "Service Start",
-                            text = "Toggling ON: Sending START_SERVICE intent (API < 24)",
-                            subText = "Lifecycle Event"
-                        ))
-                    }
-                    val intent = Intent(this, NotificationListener::class.java)
-                    intent.action = "START_SERVICE"
-                    startService(intent)
-                }
+                    startNotificationService()
             } else {
                 // Turning OFF
                 Log.v(TAG, "Toggling OFF: Sending STOP_SERVICE intent")
@@ -1564,6 +1535,15 @@ class AdSilenceActivity : Activity() {
         if (!isXiaomi()) return
         
         val preference = Preference(applicationContext)
+        
+        // If we just came back from Autostart settings, try to restart the service
+        if (hasOpenedAutostartSettings) {
+             Log.v(TAG, "Returned from Autostart Settings. Attempting to restart service.")
+             startNotificationService()
+             hasOpenedAutostartSettings = false
+             return // Don't show dialog immediately again
+        }
+
         // Only checking if
         // 1. App is enabled
         // 2. Notification permission is granted (so we expect service to run)
@@ -1601,6 +1581,7 @@ class AdSilenceActivity : Activity() {
                     "com.miui.permcenter.autostart.AutoStartManagementActivity"
                 )
                 startActivity(intent)
+                hasOpenedAutostartSettings = true
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to open MIUI Autostart settings", e)
                 Toast.makeText(this, "Could not open Autostart settings directly. Please go to Autostart settings and enable it manually.", Toast.LENGTH_LONG).show()
@@ -1622,6 +1603,44 @@ class AdSilenceActivity : Activity() {
         dialog.show()
     }
 
+    private fun startNotificationService() {
+        val preference = Preference(applicationContext)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            Log.v(TAG, "Requesting Rebind (API >= 24)")
+            if (preference.isDebugLogEnabled()) {
+                LogManager.addLifecycleLog(LogEntry(
+                    appName = "AdSilence",
+                    timestamp = System.currentTimeMillis(),
+                    isAd = false,
+                    title = "Service Rebind",
+                    text = "Requesting Rebind (API >= 24)",
+                    subText = "Lifecycle Event"
+                ))
+            }
+            try {
+                android.service.notification.NotificationListenerService.requestRebind(
+                    android.content.ComponentName(this, NotificationListener::class.java)
+                )
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to request rebind", e)
+            }
+        } else {
+            Log.v(TAG, "Sending START_SERVICE intent (API < 24)")
+             if (preference.isDebugLogEnabled()) {
+                LogManager.addLifecycleLog(LogEntry(
+                    appName = "AdSilence",
+                    timestamp = System.currentTimeMillis(),
+                    isAd = false,
+                    title = "Service Start",
+                    text = "Sending START_SERVICE intent (API < 24)",
+                    subText = "Lifecycle Event"
+                ))
+            }
+            val intent = Intent(this, NotificationListener::class.java)
+            intent.action = "START_SERVICE"
+            startService(intent)
+        }
+    }
 }
 
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -123,4 +123,10 @@
     <string name="jio_saavn_pkg_name" translatable="false">com.jio.media.jiobeats</string>
     <string name="jio_saavn_ad_string" translatable="false">Advertisement</string>
     <string name="jio_saavn" translatable="false">Jio Saavn</string>
+
+    <!-- MIUI Autostart Strings -->
+    <string name="miui_autostart_title">Enable Autostart</string>
+    <string name="miui_autostart_message">On Xiaomi/MIUI devices, you must enable \'Autostart\' for Ad-silence to work reliability in the background. Please enable it in the next screen.</string>
+    <string name="miui_autostart_button">Open Settings</string>
+    <string name="miui_autostart_ignore">Ignore</string>
 </resources>


### PR DESCRIPTION
This **PR** fixes Fixes issue where notification listener fails to start on MIUI devices. 

Adds: 
- Autostart required dialog for Xiaomi/Redmi/POCO devices.
- Auto-restart logic for notification listener service after returning from settings.

closes #316 
<img width="354" height="750" alt="Screenshot 2026-01-09 at 8 44 02 PM" src="https://github.com/user-attachments/assets/b8899c7c-f347-4829-bb6a-39fb78f09f4a" />
