### PR TITLE
Mute specific apps only using root

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 - Minimal UI, Lightweight & App size **less than 150KB**
 - Debug log directly integrated in the app to help with easier debugging
 - Supports casting (google chromecast..etc) 
+- With ROOT access, individual apps can be muted without muting other apps
 - **Fully Configurable**: Edit preloaded apps, add new custom apps, and adjust keywords or unmute delays for precise control.
 - No inapp purchases or ads
 - Open source

--- a/app/src/main/java/bluepie/ad_silence/AdSilenceActivity.kt
+++ b/app/src/main/java/bluepie/ad_silence/AdSilenceActivity.kt
@@ -1512,6 +1512,23 @@ class AdSilenceActivity : Activity() {
             }
         }
 
+        dialogView.findViewById<Switch>(R.id.switch_root_mute)?.apply {
+            isChecked = preference.isRootMuteEnabled()
+            setOnCheckedChangeListener { _, isChecked ->
+                preference.setRootMuteEnabled(isChecked)
+                if (preference.isDebugLogEnabled()) {
+                    LogManager.addLog(LogEntry(
+                        appName = "AdSilence",
+                        timestamp = System.currentTimeMillis(),
+                        isAd = false,
+                        title = "Setting Changed",
+                        text = "Root Mute: $isChecked",
+                        subText = "Settings"
+                    ))
+                }
+            }
+        }
+
         dialogView.findViewById<Button>(R.id.btn_close_settings)?.setOnClickListener {
             dialog.dismiss()
         }

--- a/app/src/main/java/bluepie/ad_silence/NotificationListener.kt
+++ b/app/src/main/java/bluepie/ad_silence/NotificationListener.kt
@@ -22,6 +22,7 @@ class NotificationListener : NotificationListenerService() {
     private val handler = Handler(Looper.getMainLooper())
     private var unmuteRunnable: Runnable? = null
     private lateinit var castMuteManager: CastMuteManager
+    private lateinit var rootMuteManager: RootMuteManager
     
     // MediaRouter related variables
     private var mediaRouter: MediaRouter? = null
@@ -58,6 +59,7 @@ class NotificationListener : NotificationListenerService() {
         audioManager = applicationContext.getSystemService(AUDIO_SERVICE) as AudioManager
         appNotificationHelper = AppNotificationHelper(applicationContext)
         castMuteManager = CastMuteManager(applicationContext)
+        rootMuteManager = RootMuteManager(applicationContext)
 
         // Initialize MediaRouter on main thread
         handler.post {
@@ -325,12 +327,23 @@ class NotificationListener : NotificationListenerService() {
                                             }
                                         }
                                     }
+
+                                    // Check for root
+                                    val isRoot = preference.isRootMuteEnabled() && !preference.isMuteEntireDeviceEnabled()
+                                    if (isRoot) {
+                                        val packageMuted = rootMuteManager.isPackageMuted(packageName)
+                                        if (packageMuted != null) {
+                                            isMusicStreamMuted = packageMuted
+                                        }
+                                    }
                                     
                                     if (!isMuted || !isMusicStreamMuted) {
                                         Log.v(TAG, "'MusicStream' muted? -> $isMusicStreamMuted")
                                         Log.v(TAG, "Ad detected muting, state-> $isMuted to ${!isMuted}, currentPackage: $currentPackage")
-                                        
-                                        if (isCasting) {
+
+                                        if (isRoot) {
+                                            rootMuteManager.mutePackage(packageName, appNotificationHelper, preference)
+                                        } else if (isCasting) {
                                             if (route != null && route.playbackType == MediaRouter.RouteInfo.PLAYBACK_TYPE_REMOTE) {
                                                 Log.v(TAG, "Casting detected on route: ${route.name}. Muting remote volume.")
                                                 if (isDebugEnabled) {
@@ -382,7 +395,10 @@ class NotificationListener : NotificationListenerService() {
                                         if (unmuteRunnable == null) {
                                             unmuteRunnable = Runnable {
                                                 val route = this@NotificationListener.currentRoute
-                                                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+                                                if (preference.isRootMuteEnabled() && !preference.isMuteEntireDeviceEnabled()) {
+                                                    castMuteManager.resetState()
+                                                    rootMuteManager.unmutePackage(packageName, appNotificationHelper, preference)
+                                                } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
                                                     Log.v(TAG, "Not an ad, Unmuting, < M")
                                                     // for android 5 & 5.1, unmute has to be done, count x mutedCount
                                                     // Check for casting (Route or Fallback)

--- a/app/src/main/java/bluepie/ad_silence/Preference.kt
+++ b/app/src/main/java/bluepie/ad_silence/Preference.kt
@@ -217,6 +217,20 @@ class Preference(private val context: Context) {
         }
     }
 
+    private val ROOT_MUTE_ENABLED = "RootMuteEnabled"
+    private val ROOT_MUTE_ENABLED_DEFAULT = false
+
+    fun isRootMuteEnabled(): Boolean {
+        return preference.getBoolean(ROOT_MUTE_ENABLED, ROOT_MUTE_ENABLED_DEFAULT)
+    }
+
+    fun setRootMuteEnabled(status: Boolean) {
+        Log.v(TAG, "[configRootMuteEnabled] ${isRootMuteEnabled()} -> $status")
+        preference.edit {
+            putBoolean(ROOT_MUTE_ENABLED, status).commit()
+        }
+    }
+
     private val CUSTOM_APPS = "CustomApps"
 
     companion object {

--- a/app/src/main/java/bluepie/ad_silence/RootMuteManager.kt
+++ b/app/src/main/java/bluepie/ad_silence/RootMuteManager.kt
@@ -1,0 +1,171 @@
+package bluepie.ad_silence
+
+import android.content.Context
+import java.io.BufferedReader
+import java.io.DataOutputStream
+import java.io.InputStreamReader
+import java.util.HashSet
+import kotlin.text.split
+
+class RootMuteManager(private val context: Context) {
+    private val PROPERTY_PLAY = "PLAY_AUDIO"
+    private val PROPERTY_FOCUS = "TAKE_AUDIO_FOCUS"
+
+    private val MUTE_PLAY = "deny"
+    private val MUTE_FOCUS = "ignore"
+    private val UNMUTE_PLAY = "allow"
+    private val UNMUTE_FOCUS = "allow"
+
+    private val FIELD_PLAY_STATUS = "Default mode"
+    private val FIELD_FOCUS_STATUS = "TAKE_AUDIO_FOCUS"
+
+    private var mutedPackages = HashSet<String>()
+
+    fun getPackageName(app: SupportedApps): List<String> {
+        val preference = Preference(context)
+        return when (app) {
+            SupportedApps.ACCURADIO -> arrayListOf(context.getString(R.string.accuradio_pkg_name))
+            SupportedApps.SPOTIFY -> arrayListOf(context.getString(R.string.spotify_package_name))
+            SupportedApps.TIDAL -> arrayListOf(context.getString(R.string.tidal_package_name))
+            SupportedApps.SPOTIFY_LITE -> arrayListOf(context.getString(R.string.spotify_lite_package_name))
+            SupportedApps.PANDORA -> arrayListOf(context.getString(R.string.pandora_package_name))
+            SupportedApps.LiveOne -> arrayListOf(context.getString(R.string.liveOne_package_name))
+            SupportedApps.Soundcloud -> arrayListOf(context.getString(R.string.soundcloud_package_name))
+            SupportedApps.JIO_SAAVN -> arrayListOf(context.getString(R.string.jio_saavn_pkg_name))
+            SupportedApps.CUSTOM -> preference.getCustomApps().filter { a -> a.isEnabled }.map { a -> a.packageName }
+            else -> ArrayList()
+        }
+    }
+
+    private fun getConfiguredApps(context: Context): List<SupportedApps> {
+        val preference = Preference(context)
+        val apps = SupportedApps.values().filter { a -> preference.isAppConfigured(a) }
+        return if (preference.getCustomApps().isEmpty()) {
+            apps
+        } else {
+            apps + SupportedApps.CUSTOM
+        }
+    }
+
+    private fun getConfiguredPackages(): List<String> {
+        return getConfiguredApps(context).flatMap { a -> getPackageName(a) }
+    }
+
+    private fun getAppProperty(appPackage: String, property: String, field: String): String? {
+        val result: BufferedReader
+        try {
+            val su = Runtime.getRuntime().exec("su")
+            val command = DataOutputStream(su.outputStream)
+
+            command.writeBytes("appops get $appPackage $property\n")
+            command.flush()
+
+            command.writeBytes("exit\n")
+            command.flush()
+            su.waitFor()
+
+            result = BufferedReader(InputStreamReader(su.inputStream))
+        } catch (_: Exception) {
+            return null
+        }
+
+        var line = result.readLine()
+        while (line != null) {
+            for (f in line.split(';')) {
+                val kv = f.split(':', limit = 2)
+                if (kv.size < 2) continue
+
+                if (kv[0].trim() == field) {
+                    return kv[1].trim()
+                }
+            }
+            line = result.readLine()
+        }
+
+        return null
+    }
+
+    fun isPackageMuted(pack: String): Boolean? {
+        val statePlay = getAppProperty(pack, PROPERTY_PLAY, FIELD_PLAY_STATUS)
+        val stateFocus = getAppProperty(pack, PROPERTY_FOCUS, FIELD_FOCUS_STATUS)
+        if (statePlay == null || stateFocus == null) {
+            return null
+        }
+
+        if ((statePlay != MUTE_PLAY && statePlay != UNMUTE_PLAY) || (stateFocus != MUTE_FOCUS && stateFocus != UNMUTE_FOCUS)) {
+            return null
+        }
+
+        return statePlay != UNMUTE_PLAY || stateFocus != UNMUTE_FOCUS
+    }
+
+    fun mutePackage(pack: String, addNotificationHelper: AppNotificationHelper?, preference: Preference) {
+        try {
+            val su = Runtime.getRuntime().exec("su")
+            val outputStream = DataOutputStream(su.outputStream)
+
+            outputStream.writeBytes("appops set $pack $PROPERTY_PLAY $MUTE_PLAY\n")
+            outputStream.writeBytes("appops set $pack $PROPERTY_FOCUS $MUTE_FOCUS\n")
+            outputStream.flush()
+
+            outputStream.writeBytes("exit\n")
+            outputStream.flush()
+            su.waitFor()
+        } catch (_: Exception) {
+            return
+        }
+
+        mutedPackages.add(pack)
+
+        if (preference.isDebugLogEnabled()) {
+            LogManager.addLifecycleLog(LogEntry(
+                appName = "AdSilence",
+                timestamp = System.currentTimeMillis(),
+                isAd = true,
+                title = "Root Mute Executed for package \"$pack\"",
+                text = "Audio playback disabled for package",
+                subText = "Action"
+            ))
+        }
+
+        this.updateNotification("AdSilence, ad-detected", preference, addNotificationHelper)
+    }
+
+    fun unmutePackage(pack: String, addNotificationHelper: AppNotificationHelper?, preference: Preference) {
+        try {
+            val su = Runtime.getRuntime().exec("su")
+            val outputStream = DataOutputStream(su.outputStream)
+
+            outputStream.writeBytes("appops set $pack $PROPERTY_PLAY $UNMUTE_PLAY\n")
+            outputStream.writeBytes("appops set $pack $PROPERTY_FOCUS $UNMUTE_FOCUS\n")
+            outputStream.flush()
+
+            outputStream.writeBytes("exit\n")
+            outputStream.flush()
+            su.waitFor()
+        } catch (_: Exception) {
+            return
+        }
+
+        mutedPackages.remove(pack)
+
+        if (preference.isDebugLogEnabled()) {
+            LogManager.addLifecycleLog(LogEntry(
+                appName = "AdSilence",
+                timestamp = System.currentTimeMillis(),
+                isAd = true,
+                title = "Root Unmute Executed for package \"$pack\"",
+                text = "Audio playback enabled for package",
+                subText = "Action"
+            ))
+        }
+
+        this.updateNotification("AdSilence, ad-detected", preference, addNotificationHelper)
+    }
+
+    private fun updateNotification(msg: String, preference: Preference, addNotificationHelper: AppNotificationHelper?) {
+        if (preference.isNotificationsEnabled()) {
+            addNotificationHelper?.updateNotification(msg)
+        }
+    }
+}

--- a/app/src/main/res/layout/dialog_settings.xml
+++ b/app/src/main/res/layout/dialog_settings.xml
@@ -149,6 +149,43 @@
             
         </LinearLayout>
 
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:layout_marginTop="16dp">
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/root_mute_title"
+                    android:textColor="?android:attr/textColorPrimary"
+                    android:textSize="14sp" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/root_mute_desc"
+                    android:textColor="?android:attr/textColorSecondary"
+                    android:textSize="12sp" />
+
+            </LinearLayout>
+
+            <Switch
+                android:id="@+id/switch_root_mute"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp" />
+
+        </LinearLayout>
+
     </LinearLayout>
 
     <Button

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -118,6 +118,9 @@
     <string name="casting_mute_title">Casting</string>
     <string name="casting_mute_desc">Mute ads while casting to other devices (e.g. Google Home, Chromecast).</string>
 
+    <string name="root_mute_title">Root</string>
+    <string name="root_mute_desc">Use ROOT access to mute apps directly, without changing sound volumes.</string>
+
     <string name="reset_app_configuration">Reset App Configuration</string>
     <string name="reset_custom_app_message_format">Are you sure? Your changes for %1$s will be reset to default.</string>
     <string name="jio_saavn_pkg_name" translatable="false">com.jio.media.jiobeats</string>

--- a/fastlane/metadata/android/en-US/title.txt
+++ b/fastlane/metadata/android/en-US/title.txt
@@ -1,0 +1,1 @@
+Ad-silence

--- a/fastlane/metadata/android/en-US/title.txt 
+++ b/fastlane/metadata/android/en-US/title.txt 
@@ -1,1 +1,0 @@
-Ad-silence


### PR DESCRIPTION
When this function is enabled, other apps that produce audio (like navigation) keep playing while the ad is muted. Unfortunately this only works with root privileges. It is only tested for Spotify