### PR TITLE
Handle notification removal to prevent stuck mute

### DIFF
--- a/app/src/main/java/bluepie/ad_silence/NotificationListener.kt
+++ b/app/src/main/java/bluepie/ad_silence/NotificationListener.kt
@@ -250,6 +250,84 @@ class NotificationListener : NotificationListenerService() {
         }
     }
 
+    override fun onNotificationRemoved(sbn: StatusBarNotification?) {
+        super.onNotificationRemoved(sbn)
+        val preference = Preference(applicationContext)
+
+        if (!preference.isEnabled() || !isMuted) {
+            return
+        }
+
+        sbn?.let {
+            val app = AppNotification(applicationContext, it.notification, sbn.packageName)
+            if (preference.isAppConfigured(app.getApp(), app.packageName)) {
+                Log.v(TAG, "Notification removed for configured app: ${app.getApp()} (${sbn.packageName}), scheduling unmute")
+
+                if (preference.isDebugLogEnabled()) {
+                    LogManager.addLifecycleLog(LogEntry(
+                        appName = "AdSilence",
+                        timestamp = System.currentTimeMillis(),
+                        isAd = false,
+                        title = "Notification Removed",
+                        text = "Notification removed for ${app.getApp()} (${sbn.packageName}), scheduling unmute",
+                        subText = "Action"
+                    ))
+                }
+
+                // Cancel any pending unmute
+                unmuteRunnable?.let {
+                    handler.removeCallbacks(it)
+                    unmuteRunnable = null
+                }
+
+                unmuteRunnable = Runnable {
+                    var isCasting = false
+                    var isRemoteRoute = false
+                    var currentRoute: MediaRouter.RouteInfo? = null
+
+                    if (preference.isCastingMuteEnabled()) {
+                        currentRoute = this@NotificationListener.currentRoute
+                        isRemoteRoute = currentRoute != null && currentRoute.playbackType == MediaRouter.RouteInfo.PLAYBACK_TYPE_REMOTE
+                        val fallbackController = if (!isRemoteRoute) getMediaControllerForCasting() else null
+                        isCasting = isRemoteRoute || fallbackController != null
+                    }
+
+                    if (isCasting) {
+                        if (isRemoteRoute && currentRoute?.volumeHandling == MediaRouter.RouteInfo.PLAYBACK_VOLUME_VARIABLE && originalRemoteVolume != -1) {
+                            val routeToRestore = currentRoute
+                            Log.v(TAG, "Restoring remote volume to $originalRemoteVolume")
+                            handler.post {
+                                routeToRestore?.requestSetVolume(originalRemoteVolume)
+                                originalRemoteVolume = -1
+                            }
+                        } else {
+                            castMuteManager.tryUnmute(this@NotificationListener)
+                        }
+                    } else {
+                        castMuteManager.resetState()
+                        Utils().unmute(audioManager, appNotificationHelper, app.getApp(), preference)
+                    }
+
+                    isMuted = false
+
+                    if (preference.isDebugLogEnabled()) {
+                        LogManager.addLifecycleLog(LogEntry(
+                            appName = "AdSilence",
+                            timestamp = System.currentTimeMillis(),
+                            isAd = false,
+                            title = "Unmuted (Notification Removed)",
+                            text = "Unmuted after notification removal for ${app.getApp()} (${sbn.packageName})",
+                            subText = "Action"
+                        ))
+                    }
+                    unmuteRunnable = null
+                }
+
+                handler.postDelayed(unmuteRunnable!!, 300)
+            }
+        }
+    }
+
     override fun onNotificationPosted(sbn: StatusBarNotification?) {
         super.onNotificationPosted(sbn)
         val preference = Preference(applicationContext)


### PR DESCRIPTION
When a music app's notification is removed (app crash, user dismisses, or app closes) while Ad-silence has muted the audio stream, the device stays muted indefinitely because the service only unmutes in response to `onNotificationPosted`. This change adds an `onNotificationRemoved` handler that schedules an unmute when a notification from a configured app is removed while the service is in a muted state, following the same casting-aware logic and delayed-run pattern already used by the existing unmute path.

The implementation mirrors the existing unmute logic in `onNotificationPosted`, including the same casting detection, volume restoration, and logging patterns. It is gated behind the existing `isEnabled` and `isMuted` guards, and only acts on notifications from apps the user has configured. The 300ms delay follows the same race-condition avoidance pattern already used elsewhere in the `codebase`. No existing behavior is changed.
