### PR TITLE
fix: hide controls until notification access is granted

### DIFF
--- a/app/src/main/java/bluepie/ad_silence/AdSilenceActivity.kt
+++ b/app/src/main/java/bluepie/ad_silence/AdSilenceActivity.kt
@@ -48,6 +48,7 @@ class AdSilenceActivity : Activity() {
         // handleHibernation()
         configureViewsWithLinks()
         configureBatteryOptimization()
+        updatePermissionGatedUi()
     }
 
     override fun onResume() {
@@ -61,6 +62,7 @@ class AdSilenceActivity : Activity() {
         // handleHibernation()
         configureViewsWithLinks()
         configureBatteryOptimization()
+        updatePermissionGatedUi()
         checkAndPromptForMiuiAutostart()
     }
 
@@ -107,6 +109,19 @@ class AdSilenceActivity : Activity() {
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             notificationPostingPermission()
+        }
+    }
+
+    private fun updatePermissionGatedUi() {
+        val hasNotificationAccess = checkNotificationListenerPermission(applicationContext)
+        val visibility = if (hasNotificationAccess) View.VISIBLE else View.GONE
+
+        findViewById<View>(R.id.notification_updates_container)?.visibility = visibility
+        findViewById<View>(R.id.notification_update_help)?.visibility = visibility
+        findViewById<View>(R.id.app_controls_container)?.visibility = visibility
+
+        if (!hasNotificationAccess) {
+            findViewById<View>(R.id.battery_optimization_container)?.visibility = View.GONE
         }
     }
 
@@ -1642,6 +1657,5 @@ class AdSilenceActivity : Activity() {
         }
     }
 }
-
 
 

--- a/app/src/main/res/layout/activity_ad_silence.xml
+++ b/app/src/main/res/layout/activity_ad_silence.xml
@@ -97,7 +97,9 @@
             android:layout_height="wrap_content"
             android:layout_marginBottom="24dp"
             android:gravity="center_vertical"
-            android:orientation="horizontal">
+            android:orientation="horizontal"
+            android:visibility="gone"
+            tools:visibility="visible">
 
             <TextView
                 android:id="@+id/notification_updates_label"
@@ -116,13 +118,16 @@
         </LinearLayout>
 
         <TextView
+            android:id="@+id/notification_update_help"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="-24dp"
             android:layout_marginBottom="16dp"
             android:text="@string/notification_update_help"
             android:textColor="?android:attr/textColorSecondary"
-            android:textSize="12sp" />
+            android:textSize="12sp"
+            android:visibility="gone"
+            tools:visibility="visible" />
 
         <Button
             android:id="@+id/grant_permission"
@@ -136,12 +141,15 @@
 
     <!-- Ad-Muting Status Card -->
     <LinearLayout
+        android:id="@+id/app_controls_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
         android:background="@drawable/bg_card_rounded"
         android:orientation="vertical"
-        android:padding="16dp">
+        android:padding="16dp"
+        android:visibility="gone"
+        tools:visibility="visible">
 
         <LinearLayout
             android:layout_width="match_parent"


### PR DESCRIPTION
This **PR** hides configuration and ad-muting controls until notification access has been granted.

Changes:
- Shows a focused setup screen before notification access is granted.
- Reveals notification updates and ad-muting controls when the user returns from Android Settings.
- Keeps Android 13+ notification-posting permission optional.
- Updates the Custom App wiki with the required setup step and restricted-settings help link.